### PR TITLE
Add a TwoWayEnv and an Observation factory

### DIFF
--- a/highway_env/__init__.py
+++ b/highway_env/__init__.py
@@ -16,6 +16,12 @@ register(
 )
 
 register(
+    id='highway-continuous-line-v0',
+    entry_point='highway_env.envs:ContinuousLineEnv',
+    tags={'wrapper_config.TimeLimit.max_episode_steps': 15}
+)
+
+register(
     id='highway-parking-v0',
     entry_point='highway_env.envs:ParkingEnv',
     tags={'wrapper_config.TimeLimit.max_episode_steps': 20}

--- a/highway_env/__init__.py
+++ b/highway_env/__init__.py
@@ -16,8 +16,8 @@ register(
 )
 
 register(
-    id='highway-continuous-line-v0',
-    entry_point='highway_env.envs:ContinuousLineEnv',
+    id='highway-two-way-v0',
+    entry_point='highway_env.envs:TwoWayEnv',
     tags={'wrapper_config.TimeLimit.max_episode_steps': 15}
 )
 

--- a/highway_env/envs/__init__.py
+++ b/highway_env/envs/__init__.py
@@ -3,3 +3,4 @@ from highway_env.envs.highway_env import HighwayEnv
 from highway_env.envs.merge_env import MergeEnv
 from highway_env.envs.roundabout_env import RoundaboutEnv
 from highway_env.envs.parking_env import ParkingEnv
+from highway_env.envs.continuous_line_env import ContinuousLineEnv

--- a/highway_env/envs/__init__.py
+++ b/highway_env/envs/__init__.py
@@ -3,4 +3,4 @@ from highway_env.envs.highway_env import HighwayEnv
 from highway_env.envs.merge_env import MergeEnv
 from highway_env.envs.roundabout_env import RoundaboutEnv
 from highway_env.envs.parking_env import ParkingEnv
-from highway_env.envs.continuous_line_env import ContinuousLineEnv
+from highway_env.envs.two_way_env import TwoWayEnv

--- a/highway_env/envs/abstract.py
+++ b/highway_env/envs/abstract.py
@@ -130,7 +130,7 @@ class AbstractEnv(gym.Env):
         # Add ego-vehicle
         df = pandas.DataFrame.from_records([self.vehicle.to_dict()])[self.KIN_OBS_FEATURES]
         # Normalize values
-        MAX_ROAD_LANES = 4
+        MAX_ROAD_LANES = 1
         road_width = AbstractLane.DEFAULT_WIDTH * MAX_ROAD_LANES
         df.loc[0, 'x'] = 0
         df.loc[0, 'y'] = utils.remap(df.loc[0, 'y'], [0, road_width], [0, 1])
@@ -146,7 +146,7 @@ class AbstractEnv(gym.Env):
                            ignore_index=True)
 
             # Normalize values
-            delta_v = 2*(MDPVehicle.SPEED_MAX - MDPVehicle.SPEED_MIN)
+            delta_v = 2*MDPVehicle.SPEED_MAX
             df.loc[1:, 'x'] = utils.remap(df.loc[1:, 'x'], [-self.PERCEPTION_DISTANCE, self.PERCEPTION_DISTANCE], [-1, 1])
             df.loc[1:, 'y'] = utils.remap(df.loc[1:, 'y'], [-road_width, road_width], [-1, 1])
             df.loc[1:, 'vx'] = utils.remap(df.loc[1:, 'vx'], [-delta_v, delta_v], [-1, 1])

--- a/highway_env/envs/continuous_line_env.py
+++ b/highway_env/envs/continuous_line_env.py
@@ -1,0 +1,135 @@
+from __future__ import division, print_function, absolute_import
+import numpy as np
+
+from highway_env import utils
+from highway_env.envs.abstract import AbstractEnv
+from highway_env.road.lane import LineType, StraightLane, SineLane
+from highway_env.road.road import Road, RoadNetwork
+from highway_env.vehicle.control import ControlledVehicle, MDPVehicle
+from highway_env.vehicle.dynamics import Obstacle
+
+
+class ContinuousLineEnv(AbstractEnv):
+    """
+        A highway merge negotiation environment.
+
+        The ego-vehicle is driving on a highway and approached a merge, with some vehicles incoming on the access ramp.
+        It is rewarded for maintaining a high velocity and avoiding collisions, but also making room for merging
+        vehicles.
+    """
+
+    COLLISION_REWARD = 0
+    LEFT_LANE_CONSTRAINT = 1
+    LEFT_LANE_REWARD = 0.2
+    HIGH_VELOCITY_REWARD = 0.8
+
+    KIN_OBS_FEATURES = ['x', 'y', 'vx', 'vy']
+    KIN_OBS_VEHICLES = 6
+
+    DEFAULT_CONFIG = {"other_vehicles_type": "highway_env.vehicle.behavior.IDMVehicle",
+                      "centering_position": [0.3, 0.5]}
+
+    def __init__(self):
+        super(ContinuousLineEnv, self).__init__()
+        self.config = self.DEFAULT_CONFIG.copy()
+        self.observation_type = "time_to_collision"
+        self.steps = 0
+        self.reset()
+
+    def configure(self, config):
+        self.config.update(config)
+
+    def step(self, action):
+        self.steps += 1
+        return super(ContinuousLineEnv, self).step(action)
+
+    def _observation(self):
+        return super(ContinuousLineEnv, self)._observation()
+
+    def _reward(self, action):
+        """
+            The vehicle is rewarded for driving with high velocity on lanes to the right and avoiding collisions, but
+            an additional altruistic penalty is also suffered if any vehicle on the merging lane has a low velocity.
+        :param action: the action performed
+        :return: the reward of the state-action transition
+        """
+        neighbours = self.road.network.all_side_lanes(self.vehicle.lane_index)
+
+        reward = self.HIGH_VELOCITY_REWARD * self.vehicle.velocity_index / (self.vehicle.SPEED_COUNT - 1) \
+            + self.LEFT_LANE_REWARD * (len(neighbours) - 1 - self.vehicle.target_lane_index[2]) / (len(neighbours) - 1)
+        lambda_ = 0
+        reward -= lambda_ * self._constraint(action)
+        if lambda_ > 1:
+            reward /= lambda_
+        # return utils.remap(reward,
+        #                    [-lambda_, self.HIGH_VELOCITY_REWARD],
+        #
+        return reward
+
+    def _is_terminal(self):
+        """
+            The episode is over if the ego vehicle crashed or the time is out.
+        """
+        return self.vehicle.crashed
+
+    def _constraint(self, action):
+        """
+            The constraint signal is the occurrence of collision
+        """
+        return float(self.vehicle.crashed) + float(self.vehicle.lane_index[2] == 0)/15
+
+    def reset(self):
+        self.steps = 0
+        self._make_road()
+        self._make_vehicles()
+        return self._observation()
+
+    def _make_road(self):
+        """
+            Make a road composed of a straight highway and a merging lane.
+        :return: the road
+        """
+        net = RoadNetwork()
+
+        # Highway lanes
+        length = 800
+        net.add_lane("a", "b", StraightLane([0, 0], [length, 0],
+                                            line_types=[LineType.CONTINUOUS_LINE, LineType.STRIPED]))
+        net.add_lane("a", "b", StraightLane([0, StraightLane.DEFAULT_WIDTH], [length, StraightLane.DEFAULT_WIDTH],
+                                            line_types=[LineType.NONE, LineType.CONTINUOUS_LINE]))
+        net.add_lane("b", "a", StraightLane([length, 0], [0, 0],
+                                            line_types=[LineType.NONE, LineType.NONE]))
+
+        road = Road(network=net, np_random=self.np_random)
+        self.road = road
+
+    def _make_vehicles(self):
+        """
+            Populate a road with several vehicles on the highway and on the merging lane, as well as an ego-vehicle.
+        :return: the ego-vehicle
+        """
+        road = self.road
+        ego_vehicle = MDPVehicle(road, road.network.get_lane(("a", "b", 1)).position(30, 0), velocity=30)
+        road.vehicles.append(ego_vehicle)
+        self.vehicle = ego_vehicle
+
+        vehicles_type = utils.class_from_path(self.config["other_vehicles_type"])
+        for i in range(3):
+            self.road.vehicles.append(
+                vehicles_type(road,
+                              position=road.network.get_lane(("a", "b", 1))
+                              .position(70+40*i + 10*self.np_random.randn(), 0),
+                              heading=road.network.get_lane(("a", "b", 1)).heading_at(70+40*i),
+                              velocity=24 + 2*self.np_random.randn(),
+                              enable_lane_change=False)
+            )
+        for i in range(2):
+            v = vehicles_type(road,
+                              position=road.network.get_lane(("b", "a", 0))
+                              .position(200+100*i + 10*self.np_random.randn(), 0),
+                              heading=road.network.get_lane(("b", "a", 0)).heading_at(200+100*i),
+                              velocity=20 + 5*self.np_random.randn(),
+                              enable_lane_change=False)
+            v.target_lane_index = ("b", "a", 0)
+            self.road.vehicles.append(v)
+

--- a/highway_env/envs/finite_mdp.py
+++ b/highway_env/envs/finite_mdp.py
@@ -90,7 +90,7 @@ def compute_ttc_grid(env, time_quantization, horizon, considered_lanes="all"):
             collision_points = [(0, 1), (-margin, 0.5), (margin, 0.5)]
             for m, cost in collision_points:
                 distance = env.vehicle.lane_distance_to(other) + m
-                other_projected_velocity = other.velocity
+                other_projected_velocity = other.velocity * np.dot(other.direction, env.vehicle.direction)
                 time_to_collision = distance / utils.not_zero(ego_velocity - other_projected_velocity)
                 if time_to_collision < 0:
                     continue

--- a/highway_env/envs/highway_env.py
+++ b/highway_env/envs/highway_env.py
@@ -56,8 +56,8 @@ class HighwayEnv(AbstractEnv):
     }
 
     def __init__(self):
-        super(HighwayEnv, self).__init__()
         self.config = self.DIFFICULTY_LEVELS["HARD"].copy()
+        super(HighwayEnv, self).__init__()
         self.steps = 0
         self.reset()
 
@@ -65,7 +65,7 @@ class HighwayEnv(AbstractEnv):
         self._create_road()
         self._create_vehicles()
         self.steps = 0
-        return self._observation()
+        return super(HighwayEnv, self).reset()
 
     def step(self, action):
         self.steps += 1

--- a/highway_env/envs/highway_env.py
+++ b/highway_env/envs/highway_env.py
@@ -25,39 +25,38 @@ class HighwayEnv(AbstractEnv):
     LANE_CHANGE_REWARD = -0
     """ The reward received at each lane change action."""
 
+    DEFAULT_CONFIG = {
+        "observation": {
+            "type": "Kinematics"
+        },
+        "initial_spacing": 2,
+        "other_vehicles_type": "highway_env.vehicle.behavior.IDMVehicle",
+        "centering_position": [0.3, 0.5],
+        "collision_reward": COLLISION_REWARD
+    }
+
     DIFFICULTY_LEVELS = {
         "EASY": {
             "lanes_count": 2,
-            "initial_spacing": 2,
             "vehicles_count": 5,
-            "duration": 20,
-            "other_vehicles_type": "highway_env.vehicle.behavior.IDMVehicle",
-            "centering_position": [0.3, 0.5],
-            "collision_reward": COLLISION_REWARD
+            "duration": 20
         },
         "MEDIUM": {
             "lanes_count": 3,
-            "initial_spacing": 2,
             "vehicles_count": 10,
-            "duration": 30,
-            "other_vehicles_type": "highway_env.vehicle.behavior.IDMVehicle",
-            "centering_position": [0.3, 0.5],
-            "collision_reward": COLLISION_REWARD
+            "duration": 30
         },
         "HARD": {
             "lanes_count": 4,
-            "initial_spacing": 3,
             "vehicles_count": 50,
-            "duration": 40,
-            "other_vehicles_type": "highway_env.vehicle.behavior.IDMVehicle",
-            "centering_position": [0.3, 0.5],
-            "collision_reward": COLLISION_REWARD
+            "duration": 40
         },
     }
 
     def __init__(self):
-        self.config = self.DIFFICULTY_LEVELS["HARD"].copy()
-        super(HighwayEnv, self).__init__()
+        config = self.DEFAULT_CONFIG.copy()
+        config.update(self.DIFFICULTY_LEVELS["HARD"])
+        super(HighwayEnv, self).__init__(config)
         self.steps = 0
         self.reset()
 
@@ -70,17 +69,6 @@ class HighwayEnv(AbstractEnv):
     def step(self, action):
         self.steps += 1
         return super(HighwayEnv, self).step(action)
-
-    def set_difficulty_level(self, level):
-        if level in self.DIFFICULTY_LEVELS:
-            logger.info("Set difficulty level to: {}".format(level))
-            self.config.update(self.DIFFICULTY_LEVELS[level])
-            self.reset()
-        else:
-            raise ValueError("Invalid difficulty level, choose among {}".format(str(self.DIFFICULTY_LEVELS.keys())))
-
-    def configure(self, config):
-        self.config.update(config)
 
     def _create_road(self):
         """
@@ -115,9 +103,6 @@ class HighwayEnv(AbstractEnv):
         return utils.remap(action_reward[action] + state_reward,
                            [self.config["collision_reward"], self.HIGH_VELOCITY_REWARD+self.RIGHT_LANE_REWARD],
                            [0, 1])
-
-    def _observation(self):
-        return super(HighwayEnv, self)._observation()
 
     def _is_terminal(self):
         """

--- a/highway_env/envs/merge_env.py
+++ b/highway_env/envs/merge_env.py
@@ -24,19 +24,17 @@ class MergeEnv(AbstractEnv):
     MERGING_VELOCITY_REWARD = -0.5
     LANE_CHANGE_REWARD = -0.05
 
-    DEFAULT_CONFIG = {"other_vehicles_type": "highway_env.vehicle.behavior.IDMVehicle",
-                      "centering_position": [0.3, 0.5]}
+    DEFAULT_CONFIG = {
+        "observation": {
+            "type": "Kinematics"
+        },
+        "other_vehicles_type": "highway_env.vehicle.behavior.IDMVehicle",
+        "centering_position": [0.3, 0.5]
+    }
 
     def __init__(self):
         super(MergeEnv, self).__init__()
-        self.config = self.DEFAULT_CONFIG.copy()
         self.reset()
-
-    def configure(self, config):
-        self.config.update(config)
-
-    def _observation(self):
-        return super(MergeEnv, self)._observation()
 
     def _reward(self, action):
         """
@@ -73,7 +71,7 @@ class MergeEnv(AbstractEnv):
     def reset(self):
         self._make_road()
         self._make_vehicles()
-        return self._observation()
+        return super(MergeEnv, self).reset()
 
     def _make_road(self):
         """

--- a/highway_env/envs/observation.py
+++ b/highway_env/envs/observation.py
@@ -1,0 +1,151 @@
+from __future__ import division, print_function, absolute_import
+import copy
+import gym
+import pandas
+from gym import spaces, logger
+from gym.utils import seeding
+import numpy as np
+
+from highway_env import utils
+from highway_env.envs.finite_mdp import finite_mdp, compute_ttc_grid
+from highway_env.envs.graphics import EnvViewer
+from highway_env.road.lane import AbstractLane
+from highway_env.vehicle.behavior import IDMVehicle
+from highway_env.vehicle.control import MDPVehicle
+from highway_env.vehicle.dynamics import Obstacle
+
+
+class ObservationType(object):
+    def space(self):
+        raise NotImplementedError()
+
+    def observe(self):
+        raise NotImplementedError()
+
+
+class TimeToCollisionObservation(ObservationType):
+    def __init__(self, env, horizon=10, **kwargs):
+        self.env = env
+        self.horizon = horizon
+
+    def space(self):
+        try:
+            return spaces.Box(shape=self.observe().shape, low=0, high=1, dtype=np.float32)
+        except AttributeError:
+            return None
+
+    def observe(self):
+        grid = compute_ttc_grid(self.env, time_quantization=1/self.env.POLICY_FREQUENCY, horizon=self.horizon)
+        padding = np.ones(np.shape(grid))
+        padded_grid = np.concatenate([padding, grid, padding], axis=1)
+        obs_lanes = 3
+        l0 = grid.shape[1] + self.env.vehicle.lane_index[2] - obs_lanes // 2
+        lf = grid.shape[1] + self.env.vehicle.lane_index[2] + obs_lanes // 2
+        clamped_grid = padded_grid[:, l0:lf+1, :]
+        repeats = np.ones(clamped_grid.shape[0])
+        repeats[np.array([0, -1])] += clamped_grid.shape[0]
+        padded_grid = np.repeat(clamped_grid, repeats.astype(int), axis=0)
+        obs_velocities = 3
+        v0 = grid.shape[0] + self.env.vehicle.velocity_index - obs_velocities // 2
+        vf = grid.shape[0] + self.env.vehicle.velocity_index + obs_velocities // 2
+        clamped_grid = padded_grid[v0:vf + 1, :, :]
+        return clamped_grid
+
+
+class KinematicObservation(ObservationType):
+    """
+        Observe the kinematics of nearby vehicles.
+    """
+    FEATURES = ['presence', 'x', 'y', 'vx', 'vy']
+
+    def __init__(self, env, features=FEATURES, vehicles_count=5, **kwargs):
+        """
+        :param env: The environment to observe
+        :param features: Names of features used in the observation
+        :param vehicles_count: Number of observed vehicles
+        """
+        self.env = env
+        self.features = features
+        self.vehicles_count = vehicles_count
+
+    def space(self):
+        return spaces.Box(shape=(len(self.features) * self.vehicles_count,), low=-1, high=1, dtype=np.float32)
+
+    def normalize(self, df):
+        """
+            Normalize the observation values.
+
+            For now, assume that the road is straight along the x axis.
+        :param Dataframe df: observation data
+        """
+        side_lanes = self.env.road.network.all_side_lanes(self.env.vehicle.lane_index)
+        x_position_range = 5.0 * MDPVehicle.SPEED_MAX
+        y_position_range = AbstractLane.DEFAULT_WIDTH * len(side_lanes)
+        velocity_range = 2*MDPVehicle.SPEED_MAX
+        df['x'] = utils.remap(df['x'], [-x_position_range, x_position_range], [-1, 1])
+        df['y'] = utils.remap(df['y'], [-y_position_range, y_position_range], [-1, 1])
+        df['vx'] = utils.remap(df['vx'], [-velocity_range, velocity_range], [-1, 1])
+        df['vy'] = utils.remap(df['vy'], [-velocity_range, velocity_range], [-1, 1])
+        return df
+
+    def observe(self):
+        # Add ego-vehicle
+        df = pandas.DataFrame.from_records([self.env.vehicle.to_dict()])[self.features]
+        # Add nearby traffic
+        close_vehicles = self.env.road.closest_vehicles_to(self.env.vehicle, self.vehicles_count - 1)
+        if close_vehicles:
+            df = df.append(pandas.DataFrame.from_records(
+                [v.to_dict(self.env.vehicle)
+                 for v in close_vehicles[-self.vehicles_count + 1:]])[self.features],
+                           ignore_index=True)
+        # Normalize
+        df = self.normalize(df)
+        # Fill missing rows
+        if df.shape[0] < self.vehicles_count:
+            rows = -np.ones((self.vehicles_count - df.shape[0], len(self.features)))
+            df = df.append(pandas.DataFrame(data=rows, columns=self.features), ignore_index=True)
+        # Reorder
+        df = df[self.features]
+        # Clip
+        obs = np.clip(df.values, -1, 1)
+        # Flatten
+        obs = np.ravel(obs)
+        return obs
+
+
+class KinematicsGoalObservation(KinematicObservation):
+    def __init__(self, env, scale, **kwargs):
+        self.scale = scale
+        super(KinematicsGoalObservation, self).__init__(env, **kwargs)
+
+    def space(self):
+        try:
+            obs = self.observe()
+            return spaces.Dict(dict(
+                desired_goal=spaces.Box(-np.inf, np.inf, shape=obs["desired_goal"].shape, dtype=np.float32),
+                achieved_goal=spaces.Box(-np.inf, np.inf, shape=obs["achieved_goal"].shape, dtype=np.float32),
+                observation=spaces.Box(-np.inf, np.inf, shape=obs["observation"].shape, dtype=np.float32),
+            ))
+        except AttributeError:
+            return None
+
+    def observe(self):
+        obs = np.ravel(pandas.DataFrame.from_records([self.env.vehicle.to_dict()])[self.features])
+        goal = np.ravel(pandas.DataFrame.from_records([self.env.goal.to_dict()])[self.features])
+        obs = {
+            "observation": obs / self.scale,
+            "achieved_goal": obs / self.scale,
+            "desired_goal": goal / self.scale
+        }
+        return obs
+
+
+def observation_factory(env, config):
+    if config["type"] == "TimeToCollision":
+        return TimeToCollisionObservation(env, **config)
+    elif config["type"] == "Kinematics":
+        return KinematicObservation(env, **config)
+    elif config["type"] == "KinematicsGoal":
+        return KinematicsGoalObservation(env, **config)
+    else:
+        raise ValueError("Unkown observation type")

--- a/highway_env/envs/parking_env.py
+++ b/highway_env/envs/parking_env.py
@@ -31,8 +31,8 @@ class ParkingEnv(AbstractEnv, GoalEnv):
         "centering_position": [0.5, 0.5]
     }
 
-    OBSERVATION_FEATURES = ['x', 'y', 'vx', 'vy', 'cos_h', 'sin_h']
-    OBSERVATION_VEHICLES = 1
+    KIN_OBS_FEATURES = ['x', 'y', 'vx', 'vy', 'cos_h', 'sin_h']
+    KIN_OBS_VEHICLES = 1
     NORMALIZE_OBS = False
 
     def __init__(self):

--- a/highway_env/envs/roundabout_env.py
+++ b/highway_env/envs/roundabout_env.py
@@ -18,22 +18,20 @@ class RoundaboutEnv(AbstractEnv):
 
     DURATION = 11
 
-    DEFAULT_CONFIG = {"other_vehicles_type": "highway_env.vehicle.behavior.IDMVehicle",
-                      "incoming_vehicle_destination": None,
-                      "centering_position": [0.5, 0.6]}
+    DEFAULT_CONFIG = {
+        "observation": {
+            "type": "Kinematics"
+        },
+        "other_vehicles_type": "highway_env.vehicle.behavior.IDMVehicle",
+        "incoming_vehicle_destination": None,
+        "centering_position": [0.5, 0.6]
+    }
 
     def __init__(self):
         super(RoundaboutEnv, self).__init__()
-        self.config = self.DEFAULT_CONFIG.copy()
         self.steps = 0
         self.reset()
         EnvViewer.SCREEN_HEIGHT = 600
-
-    def configure(self, config):
-        self.config.update(config)
-
-    def _observation(self):
-        return super(RoundaboutEnv, self)._observation()
 
     def _reward(self, action):
         reward = self.COLLISION_REWARD * self.vehicle.crashed \
@@ -51,7 +49,7 @@ class RoundaboutEnv(AbstractEnv):
         self._make_road()
         self._make_vehicles()
         self.steps = 0
-        return self._observation()
+        return super(RoundaboutEnv, self).reset()
 
     def step(self, action):
         self.steps += 1

--- a/highway_env/envs/two_way_env.py
+++ b/highway_env/envs/two_way_env.py
@@ -23,28 +23,24 @@ class TwoWayEnv(AbstractEnv):
     LEFT_LANE_REWARD = 0.2
     HIGH_VELOCITY_REWARD = 0.8
 
-    KIN_OBS_FEATURES = ['x', 'y', 'vx', 'vy']
-    KIN_OBS_VEHICLES = 6
-
-    DEFAULT_CONFIG = {"other_vehicles_type": "highway_env.vehicle.behavior.IDMVehicle",
-                      "centering_position": [0.3, 0.5]}
+    DEFAULT_CONFIG = {
+        "observation": {
+            "type": "Kinematics",
+            "features": ['x', 'y', 'vx', 'vy'],
+            "vehicles_count": 6
+        },
+        "other_vehicles_type": "highway_env.vehicle.behavior.IDMVehicle",
+        "centering_position": [0.3, 0.5]
+    }
 
     def __init__(self):
         super(TwoWayEnv, self).__init__()
-        self.config = self.DEFAULT_CONFIG.copy()
-        self.observation_type = "time_to_collision"
         self.steps = 0
         self.reset()
-
-    def configure(self, config):
-        self.config.update(config)
 
     def step(self, action):
         self.steps += 1
         return super(TwoWayEnv, self).step(action)
-
-    def _observation(self):
-        return super(TwoWayEnv, self)._observation()
 
     def _reward(self, action):
         """
@@ -74,7 +70,7 @@ class TwoWayEnv(AbstractEnv):
         self.steps = 0
         self._make_road()
         self._make_vehicles()
-        return self._observation()
+        return super(TwoWayEnv, self).reset()
 
     def _make_road(self, length = 800):
         """


### PR DESCRIPTION
- Support the use of several Observation types, including the Kinematics observation and a new Time-to-Collision observation based on the existing finite-mdp representation.
Observation are now defined as classes, and selected in the environment configuration.
- Add a new task of driving on a two-way lane with incoming traffic.