### PR TITLE
landmark is not considered a neighbour vehicle

### DIFF
--- a/highway_env/road/objects.py
+++ b/highway_env/road/objects.py
@@ -1,9 +1,9 @@
 from abc import ABC
-from typing import Sequence
+from typing import Sequence, Tuple
 
 import numpy as np
 
-from highway_env.road.road import LaneIndex
+LaneIndex = Tuple[str, str, int]
 
 
 class RoadObject(ABC):
@@ -41,7 +41,7 @@ class RoadObject(ABC):
         lane = road.network.get_lane(lane_index)
         return cls(road, lane.position(longitudinal, 0), lane.heading_at(longitudinal))
 
-    # Just added for sake of compatibility, TODO: change usages the way that this make sense.
+    # Just added for sake of compatibility
     def to_dict(self, origin_vehicle=None, observe_intentions=True):
         d = {
             'presence': 1,

--- a/highway_env/road/road.py
+++ b/highway_env/road/road.py
@@ -5,6 +5,7 @@ from typing import List, Tuple, Dict, TYPE_CHECKING, Optional
 
 from highway_env.logger import Loggable
 from highway_env.road.lane import LineType, StraightLane, AbstractLane
+from highway_env.road.objects import Landmark
 
 if TYPE_CHECKING:
     from highway_env.vehicle import kinematics
@@ -283,8 +284,6 @@ class Road(Loggable):
         """
         for vehicle in self.vehicles:
             vehicle.step(dt)
-        # TODO: create a shallow copy of vehicles list(vehicle.copy()) and pop crashed vehicles from it to reduce
-        #  complexity and prevent multiple checks
         for vehicle in self.vehicles:
             for other in self.vehicles:
                 vehicle.check_collision(other)
@@ -309,7 +308,8 @@ class Road(Loggable):
         s_front = s_rear = None
         v_front = v_rear = None
         for v in self.vehicles + self.objects:
-            if v is not vehicle and True:  # self.network.is_connected_road(v.lane_index, lane_index, same_lane=True):
+            if v is not vehicle and not isinstance(v, Landmark):  # self.network.is_connected_road(v.lane_index,
+                # lane_index, same_lane=True):
                 s_v, lat_v = lane.local_coordinates(v.position)
                 if not lane.on_lane(v.position, s_v, lat_v, margin=1):
                     continue


### PR DESCRIPTION
Regarding #81, I made little changes that make IDM vehicles neglect the `Landmark` objects at all because landmarks are not considered a neighbor vehicle to any other vehicle anymore. But they still respect the obstacles and try to change lane/break when there is an obstacle ahead.

Let me know if there is something wrong with this PR.