### PR TITLE
Configurable high-speed reward in highway-env (closes #109)

### DIFF
--- a/docs/source/environments/highway.rst
+++ b/docs/source/environments/highway.rst
@@ -36,7 +36,8 @@ Default configuration
         "vehicles_count": 50,
         "duration": 40,  # [s]
         "initial_spacing": 2,
-        "collision_reward": -1  # The reward received when colliding with a vehicle.
+        "collision_reward": -1,  # The reward received when colliding with a vehicle.
+        "reward_speed_range": [20, 30],  # [m/s] The reward for high speed is mapped linearly from this range to [0, HighwayEnv.HIGH_SPEED_REWARD].
         "simulation_frequency": 15,  # [Hz]
         "policy_frequency": 1,  # [Hz]
         "other_vehicles_type": "highway_env.vehicle.behavior.IDMVehicle",


### PR DESCRIPTION
add a new config `"reward_speed_range"` to `HighwayEnv` to configure the speed range for the reward (see #109)