### PR TITLE
collision reward update for highway-env

### DIFF
--- a/highway_env/envs/common/finite_mdp.py
+++ b/highway_env/envs/common/finite_mdp.py
@@ -54,10 +54,12 @@ def finite_mdp(env: 'AbstractEnv',
     v, l, t = grid.shape
     lanes = np.arange(l)/max(l - 1, 1)
     speeds = np.arange(v)/max(v - 1, 1)
+    
     state_reward = \
-        + env.COLLISION_REWARD * grid \
+        + env.config["collision_reward"] * grid \
         + env.RIGHT_LANE_REWARD * np.tile(lanes[np.newaxis, :, np.newaxis], (v, 1, t)) \
         + env.HIGH_SPEED_REWARD * np.tile(speeds[:, np.newaxis, np.newaxis], (1, l, t))
+    
     state_reward = np.ravel(state_reward)
     action_reward = [env.LANE_CHANGE_REWARD, 0, env.LANE_CHANGE_REWARD, 0, 0]
     reward = np.fromfunction(np.vectorize(lambda s, a: state_reward[s] + action_reward[a]),


### PR DESCRIPTION
Hi @eleurent,

Well this change is proposed based on the missing _COLLISION_REWARD_ parameter from _highway_env.py_ file. This issue was also found while executing _planners_evaluation.py_ script from `rl-agents`.

Also, I did observed that this missing _COLLISION_REWARD_ parameter is present for other environments. But, still proposing this change instead of editing _highway_env.py_ as code refactoring wise it looks like sufficient change. Hope, this change meets the required functional expectation for you. Thanks!!
