### PR TITLE
adding roof and headlights on vehicles

### DIFF
--- a/highway_env/vehicle/graphics.py
+++ b/highway_env/vehicle/graphics.py
@@ -43,14 +43,22 @@ class VehicleGraphics(object):
 
         v = vehicle
         tire_length, tire_width = 1, 0.3
+        headlight_length, headlight_width = 1, 0.6
+        roof_length, roof_width = 2.0, 1.5
 
         # Vehicle rectangle
         length = v.LENGTH + 2 * tire_length
         vehicle_surface = pygame.Surface((surface.pix(length), surface.pix(length)), flags=pygame.SRCALPHA)  # per-pixel alpha
         rect = (surface.pix(tire_length), surface.pix(length / 2 - v.WIDTH / 2), surface.pix(v.LENGTH), surface.pix(v.WIDTH))
+        rect_headlight_left = (surface.pix(v.LENGTH), surface.pix(length / 2 - (1.4*v.WIDTH) / 3), surface.pix(headlight_length), surface.pix(headlight_width))
+        rect_headlight_right = (surface.pix(v.LENGTH), surface.pix(length / 2 + (0.6*v.WIDTH) / 5), surface.pix(headlight_length), surface.pix(headlight_width))
+        rect_roof = (surface.pix(v.LENGTH/2 - tire_length/2), surface.pix(0.999*length/ 2 - 0.38625*v.WIDTH), surface.pix(roof_length), surface.pix(roof_width))
         pygame.draw.rect(vehicle_surface, cls.get_color(v, transparent), rect, 0)
         pygame.draw.rect(vehicle_surface, cls.BLACK, rect, 1)
-
+        pygame.draw.rect(vehicle_surface, cls.BLACK, rect_headlight_left, 1)
+        pygame.draw.rect(vehicle_surface, cls.BLACK, rect_headlight_right, 1)
+        pygame.draw.rect(vehicle_surface, cls.BLACK, rect_roof, 1)
+        
         # Tires
         if type(vehicle) in [Vehicle, BicycleVehicle]:
             tire_positions = [[surface.pix(tire_length), surface.pix(length / 2 - v.WIDTH / 2)],

--- a/highway_env/vehicle/graphics.py
+++ b/highway_env/vehicle/graphics.py
@@ -43,7 +43,7 @@ class VehicleGraphics(object):
 
         v = vehicle
         tire_length, tire_width = 1, 0.3
-        headlight_length, headlight_width = 0.7, 0.6
+        headlight_length, headlight_width = 0.72, 0.6
         roof_length, roof_width = 2.0, 1.5
 
         # Vehicle rectangle
@@ -179,7 +179,7 @@ class VehicleGraphics(object):
         return color
 
     @classmethod
-    def darken(cls, color, ratio=0.825):
+    def darken(cls, color, ratio=0.83):
         return (
             int(color[0] * ratio),
             int(color[1] * ratio),
@@ -187,7 +187,7 @@ class VehicleGraphics(object):
         ) + color[3:]
 
     @classmethod
-    def lighten(cls, color, ratio=0.875):
+    def lighten(cls, color, ratio=0.68):
         return (
             min(int(color[0] / ratio), 255),
             min(int(color[1] / ratio), 255),

--- a/highway_env/vehicle/graphics.py
+++ b/highway_env/vehicle/graphics.py
@@ -43,22 +43,36 @@ class VehicleGraphics(object):
 
         v = vehicle
         tire_length, tire_width = 1, 0.3
-        headlight_length, headlight_width = 1, 0.6
+        headlight_length, headlight_width = 0.6, 0.6
         roof_length, roof_width = 2.0, 1.5
 
         # Vehicle rectangle
         length = v.LENGTH + 2 * tire_length
-        vehicle_surface = pygame.Surface((surface.pix(length), surface.pix(length)), flags=pygame.SRCALPHA)  # per-pixel alpha
-        rect = (surface.pix(tire_length), surface.pix(length / 2 - v.WIDTH / 2), surface.pix(v.LENGTH), surface.pix(v.WIDTH))
-        rect_headlight_left = (surface.pix(v.LENGTH), surface.pix(length / 2 - (1.4*v.WIDTH) / 3), surface.pix(headlight_length), surface.pix(headlight_width))
-        rect_headlight_right = (surface.pix(v.LENGTH), surface.pix(length / 2 + (0.6*v.WIDTH) / 5), surface.pix(headlight_length), surface.pix(headlight_width))
-        rect_roof = (surface.pix(v.LENGTH/2 - tire_length/2), surface.pix(0.999*length/ 2 - 0.38625*v.WIDTH), surface.pix(roof_length), surface.pix(roof_width))
-        pygame.draw.rect(vehicle_surface, cls.get_color(v, transparent), rect, 0)
+        vehicle_surface = pygame.Surface((surface.pix(length), surface.pix(length)),
+                                         flags=pygame.SRCALPHA)  # per-pixel alpha
+        rect = (surface.pix(tire_length),
+                surface.pix(length / 2 - v.WIDTH / 2),
+                surface.pix(v.LENGTH),
+                surface.pix(v.WIDTH))
+        rect_headlight_left = (surface.pix(tire_length+v.LENGTH-headlight_length),
+                               surface.pix(length / 2 - (1.4*v.WIDTH) / 3),
+                               surface.pix(headlight_length),
+                               surface.pix(headlight_width))
+        rect_headlight_right = (surface.pix(tire_length+v.LENGTH-headlight_length),
+                                surface.pix(length / 2 + (0.6*v.WIDTH) / 5),
+                                surface.pix(headlight_length),
+                                surface.pix(headlight_width))
+        rect_roof = (surface.pix(v.LENGTH/2 - tire_length/2),
+                     surface.pix(0.999*length/ 2 - 0.38625*v.WIDTH),
+                     surface.pix(roof_length),
+                     surface.pix(roof_width))
+        color = cls.get_color(v, transparent)
+        pygame.draw.rect(vehicle_surface, color, rect, 0)
+        pygame.draw.rect(vehicle_surface, cls.lighten(color), rect_headlight_left, 0)
+        pygame.draw.rect(vehicle_surface, cls.lighten(color), rect_headlight_right, 0)
+        pygame.draw.rect(vehicle_surface, cls.darken(color), rect_roof, 0)
         pygame.draw.rect(vehicle_surface, cls.BLACK, rect, 1)
-        pygame.draw.rect(vehicle_surface, cls.BLACK, rect_headlight_left, 1)
-        pygame.draw.rect(vehicle_surface, cls.BLACK, rect_headlight_right, 1)
-        pygame.draw.rect(vehicle_surface, cls.BLACK, rect_roof, 1)
-        
+
         # Tires
         if type(vehicle) in [Vehicle, BicycleVehicle]:
             tire_positions = [[surface.pix(tire_length), surface.pix(length / 2 - v.WIDTH / 2)],
@@ -164,3 +178,18 @@ class VehicleGraphics(object):
             color = (color[0], color[1], color[2], 30)
         return color
 
+    @classmethod
+    def darken(cls, color, ratio=6/7):
+        return (
+            int(color[0] * ratio),
+            int(color[1] * ratio),
+            int(color[2] * ratio),
+        ) + color[3:]
+
+    @classmethod
+    def lighten(cls, color, ratio=6/7):
+        return (
+            min(int(color[0] / ratio), 255),
+            min(int(color[1] / ratio), 255),
+            min(int(color[2] / ratio), 255),
+        ) + color[3:]

--- a/highway_env/vehicle/graphics.py
+++ b/highway_env/vehicle/graphics.py
@@ -43,7 +43,7 @@ class VehicleGraphics(object):
 
         v = vehicle
         tire_length, tire_width = 1, 0.3
-        headlight_length, headlight_width = 0.6, 0.6
+        headlight_length, headlight_width = 0.7, 0.6
         roof_length, roof_width = 2.0, 1.5
 
         # Vehicle rectangle
@@ -179,7 +179,7 @@ class VehicleGraphics(object):
         return color
 
     @classmethod
-    def darken(cls, color, ratio=6/7):
+    def darken(cls, color, ratio=0.825):
         return (
             int(color[0] * ratio),
             int(color[1] * ratio),
@@ -187,7 +187,7 @@ class VehicleGraphics(object):
         ) + color[3:]
 
     @classmethod
-    def lighten(cls, color, ratio=6/7):
+    def lighten(cls, color, ratio=0.875):
         return (
             min(int(color[0] / ratio), 255),
             min(int(color[1] / ratio), 255),


### PR DESCRIPTION
Added three rectangles for headlights and roof for front and back distinction. I have tested these rectangle shapes across all environments. I wasn't keep the roof rectangle exactly consistent with respect to all environments. Hence, I have tried few combinations to give best results across all environments.

It's a bit off to the left for vehicle for highway-v0, u-turn-v0 and two-way-v0 environment but appears exactly at center for remaining environments. Hope, this distinction method doesn't look messy and helps in solving the #70 minimally. I am attaching some screenshots for reference below with respect to different environment. Thanks!!

![image](https://user-images.githubusercontent.com/19948632/108381776-27febc80-722e-11eb-9571-3205c874420d.png)
![image](https://user-images.githubusercontent.com/19948632/108381834-377e0580-722e-11eb-8014-5c320ba9be1a.png)
![image](https://user-images.githubusercontent.com/19948632/108382020-66947700-722e-11eb-8482-c41d56b015b3.png)
![image](https://user-images.githubusercontent.com/19948632/108382070-714f0c00-722e-11eb-8014-01b4272f90c3.png)
