### PR TITLE
Small fix to AbstractLane.on_lane() to handle zeroes correctly

### DIFF
--- a/highway_env/road/lane.py
+++ b/highway_env/road/lane.py
@@ -69,7 +69,7 @@ class AbstractLane(object):
         :param margin: (optional) a supplementary margin around the lane width
         :return: is the position on the lane?
         """
-        if not longitudinal or not lateral:
+        if longitudinal is None or lateral is None:
             longitudinal, lateral = self.local_coordinates(position)
         is_on = np.abs(lateral) <= self.width_at(longitudinal) / 2 + margin and \
             -self.VEHICLE_LENGTH <= longitudinal < self.length + self.VEHICLE_LENGTH


### PR DESCRIPTION
Conditional statement will treat arguments with a value of None and 0 the same. Fixed this so conditional only executes when value is None.

I believe this potentially only cause an issue on very rare occasions, since longitudinal and lateral are floats. However I came across this causing some small issues when playing around with the Highway environment where I believe a vehicle in the top lane can have a valid coordinate of 0. 