### PR TITLE
Bug fix: when using parking-env with Grayscale obs

### DIFF
--- a/highway_env/envs/common/abstract.py
+++ b/highway_env/envs/common/abstract.py
@@ -17,6 +17,15 @@ from highway_env.vehicle.kinematics import Vehicle
 
 Observation = np.ndarray
 
+# For parking env with GrayscaleObservation, the env need
+# this PARKING_OBS to calculate the reward and the info.
+# Bug fixed by Mcfly(https://github.com/McflyWZX)
+PARKING_OBS = {"observation": {
+        "type": "KinematicsGoal",
+        "features": ['x', 'y', 'vx', 'vy', 'cos_h', 'sin_h'],
+        "scales": [100, 100, 5, 5, 1, 1],
+        "normalize": False
+    }}
 
 class AbstractEnv(gym.Env):
 
@@ -54,6 +63,7 @@ class AbstractEnv(gym.Env):
         self.action_type = None
         self.action_space = None
         self.observation_type = None
+        self.observation_type_parking = None
         self.observation_space = None
         self.define_spaces()
 
@@ -126,6 +136,7 @@ class AbstractEnv(gym.Env):
         """
         Set the types and spaces of observation and action from config.
         """
+        self.observation_type_parking = observation_factory(self, PARKING_OBS["observation"])
         self.observation_type = observation_factory(self, self.config["observation"])
         self.action_type = action_factory(self, self.config["action"])
         self.observation_space = self.observation_type.space()

--- a/highway_env/envs/parking_env.py
+++ b/highway_env/envs/parking_env.py
@@ -52,6 +52,7 @@ class ParkingEnv(AbstractEnv, GoalEnv):
         if isinstance(self.observation_type, MultiAgentObservation):
             success = tuple(self._is_success(agent_obs['achieved_goal'], agent_obs['desired_goal']) for agent_obs in obs)
         else:
+            obs = self.observation_type_parking.observe()
             success = self._is_success(obs['achieved_goal'], obs['desired_goal'])
         info.update({"is_success": success})
         return info
@@ -108,7 +109,7 @@ class ParkingEnv(AbstractEnv, GoalEnv):
         return -np.power(np.dot(np.abs(achieved_goal - desired_goal), np.array(self.config["reward_weights"])), p)
 
     def _reward(self, action: np.ndarray) -> float:
-        obs = self.observation_type.observe()
+        obs = self.observation_type_parking.observe()
         obs = obs if isinstance(obs, tuple) else (obs,)
         return sum(self.compute_reward(agent_obs['achieved_goal'], agent_obs['desired_goal'], {})
                      for agent_obs in obs)
@@ -120,7 +121,7 @@ class ParkingEnv(AbstractEnv, GoalEnv):
         """The episode is over if the ego vehicle crashed or the goal is reached."""
         time = self.steps >= self.config["duration"]
         crashed = any(vehicle.crashed for vehicle in self.controlled_vehicles)
-        obs = self.observation_type.observe()
+        obs = self.observation_type_parking.observe()
         obs = obs if isinstance(obs, tuple) else (obs,)
         success = all(self._is_success(agent_obs['achieved_goal'], agent_obs['desired_goal']) for agent_obs in obs)
         return time or crashed or success


### PR DESCRIPTION
When I try to use parking-env with "GrayscaleObservation", I use the config:
`config = {

       "observation": {
           "type": "GrayscaleObservation",
           "observation_shape": (128, 64),
           "stack_size": 4,
           "weights": [0.2989, 0.5870, 0.1140],  # weights for RGB conversion
           "scaling": 1.75,
       },
       "policy_frequency": 2
   }`,
It return bugs that the **reward** and the **info** cannot be calculated correctly, than It try to view the source code of the gym and see the bug: the reward and info in parking-env need **KinematicsGoal** obs to calculate. So I add a specialized obs **observation_type_parking** to replace the obs in the **reward** and the **info** calculation in parking-env.