### PR TITLE
Import gym.wrappers.monitor error

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ sphinx_rtd_theme
 sphinxcontrib-bibtex<2.0.0
 # jupyter-sphinx
 git+git://github.com/eleurent/jupyter-sphinx@master#egg=jupyter-sphinx
-gym
+gym==0.22.0
 git+https://github.com/Farama-Foundation/gym-robotics@main
 numpy
 pygame


### PR DESCRIPTION
Hi, it seems `monitor.py` is removed from gym==0.23.0 which causes `import gym.wrappers.monitor` to fail. 