### PR TITLE
fix a bug in generating discrete actions

### DIFF
--- a/highway_env/envs/common/action.py
+++ b/highway_env/envs/common/action.py
@@ -158,7 +158,7 @@ class DiscreteAction(ContinuousAction):
     def act(self, action: int) -> None:
         cont_space = super().space()
         axes = np.linspace(cont_space.low, cont_space.high, self.actions_per_axis)
-        all_actions = list(product(axes))
+        all_actions = list(product(*zip(*axes)))
         super().act(all_actions[action])
 
 


### PR DESCRIPTION
In the original code of DiscreteAction.act, "axes" has the shape (actions_per_axis, 2), and "all_actions" is identical to "axes" except for using different containers. Therefore, it fails to generate a full set of possible actions.
To correctly generate all_actions, we can transpose "axes", and then unpack it along 1st axis before feeding it into "product" function.

The following lines reproduce the error as well as verify the fix:
"""
import gym
import highway_env

env = gym.make("highway-v0")
env.configure({
    "action": {
        "type": "DiscreteAction"
    }
})
env.reset()
env.step(4) # actions_per_axis is set as 3 by default, thus the possible actions are {0, ..., 8}
"""