### PR TITLE
Introduction of longitudinal, lateral and angular offset to lane in agent's observation space

### DIFF
--- a/docs/source/observations/index.rst
+++ b/docs/source/observations/index.rst
@@ -91,6 +91,24 @@ vehicle V    0.172      0.065      0.15         0.025
     filled with zeros. The ``presence`` feature can be used to detect such cases, since it is set to 1 for any observed
     vehicle and 0 for placeholders.
 
+===================  ===========================
+Feature                 Description
+===================  ===========================
+:math:`presence`     Disambiguate agents at 0 offset from non-existent agents.
+:math:`x`            World offset of ego vehicle or offset to ego vehicle on the x axis.
+:math:`y`            World offset of ego vehicle or offset to ego vehicle on the y axis.
+:math:`vx`           Velocity on the x axis of vehicle.
+:math:`vy`           Velocity on the y axis of vehicle.
+:math:`heading`      Heading of vehicle in radians.
+:math:`cos_h`        Trigonometric heading of vehicle.
+:math:`sin_h`        Trigonometric heading of vehicle.
+:math:`cos_d`        Trigonometric direction to the vehicle's destination.
+:math:`sin_d`        Trigonometric direction to the vehicle's destination.
+:math:`long_{off}`   Longitudinal offset to closest lane.
+:math:`lat_{off}`    Lateral offset to closest lane.
+:math:`ang_{off}`    Angular offset to closest lane.
+===================  ===========================
+
 Example configuration
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/highway_env/envs/intersection_env.py
+++ b/highway_env/envs/intersection_env.py
@@ -280,7 +280,7 @@ class ContinuousIntersectionEnv(IntersectionEnv):
             "observation": {
                 "type": "Kinematics",
                 "vehicles_count": 5,
-                "features": ["presence", "x", "y", "vx", "vy"]#, "lat_off", "ang_off"],
+                "features": ["presence", "x", "y", "vx", "vy", "long_off", "lat_off"],
             },
             "action": {
                 "type": "ContinuousAction",

--- a/highway_env/envs/intersection_env.py
+++ b/highway_env/envs/intersection_env.py
@@ -272,6 +272,25 @@ class MultiAgentIntersectionEnv(IntersectionEnv):
         })
         return config
 
+class ContinuousIntersectionEnv(IntersectionEnv):
+    @classmethod
+    def default_config(cls) -> dict:
+        config = super().default_config()
+        config.update({
+            "observation": {
+                "type": "Kinematics",
+                "vehicles_count": 5,
+                "features": ["presence", "x", "y", "vx", "vy"]#, "lat_off", "ang_off"],
+            },
+            "action": {
+                "type": "ContinuousAction",
+                "steering_range": [-np.pi / 3, np.pi / 3],
+                "longitudinal": True,
+                "lateral": True,
+                "dynamical": True
+            },
+        })
+        return config
 
 TupleMultiAgentIntersectionEnv = MultiAgentWrapper(MultiAgentIntersectionEnv)
 
@@ -279,6 +298,11 @@ TupleMultiAgentIntersectionEnv = MultiAgentWrapper(MultiAgentIntersectionEnv)
 register(
     id='intersection-v0',
     entry_point='highway_env.envs:IntersectionEnv',
+)
+
+register(
+    id='intersection-v1',
+    entry_point='highway_env.envs:ContinuousIntersectionEnv',
 )
 
 register(

--- a/highway_env/envs/intersection_env.py
+++ b/highway_env/envs/intersection_env.py
@@ -280,7 +280,7 @@ class ContinuousIntersectionEnv(IntersectionEnv):
             "observation": {
                 "type": "Kinematics",
                 "vehicles_count": 5,
-                "features": ["presence", "x", "y", "vx", "vy", "long_off", "lat_off"],
+                "features": ["presence", "x", "y", "vx", "vy", "long_off", "lat_off", "ang_off"],
             },
             "action": {
                 "type": "ContinuousAction",

--- a/highway_env/road/lane.py
+++ b/highway_env/road/lane.py
@@ -123,8 +123,12 @@ class AbstractLane(object):
         if heading is None:
             return self.distance(position)
         s, r = self.local_coordinates(position)
-        angle = np.abs(wrap_to_pi(heading - self.heading_at(s)))
+        angle = np.abs(self.local_angle(heading, s))
         return abs(r) + max(s - self.length, 0) + max(0 - s, 0) + heading_weight*angle
+
+    def local_angle(self, heading: float, long_offset: float):
+        """Compute non-normalised angle of heading to the lane."""
+        return wrap_to_pi(heading - self.heading_at(long_offset))
 
 
 class LineType:

--- a/highway_env/vehicle/kinematics.py
+++ b/highway_env/vehicle/kinematics.py
@@ -187,6 +187,14 @@ class Vehicle(RoadObject):
         else:
             return np.zeros((2,))
 
+    @property
+    def lane_offset(self) -> np.ndarray:
+        if self.lane is not None:
+            long, lat = self.lane.local_coordinates(self.position)
+            return np.array([long, lat])
+        else:
+            return np.zeros((2,))
+
     def to_dict(self, origin_vehicle: "Vehicle" = None, observe_intentions: bool = True) -> dict:
         d = {
             'presence': 1,
@@ -198,7 +206,9 @@ class Vehicle(RoadObject):
             'cos_h': self.direction[0],
             'sin_h': self.direction[1],
             'cos_d': self.destination_direction[0],
-            'sin_d': self.destination_direction[1]
+            'sin_d': self.destination_direction[1],
+            'long_off': self.lane_offset[0],
+            'lat_off': self.lane_offset[1],
         }
         if not observe_intentions:
             d["cos_d"] = d["sin_d"] = 0

--- a/highway_env/vehicle/kinematics.py
+++ b/highway_env/vehicle/kinematics.py
@@ -191,9 +191,10 @@ class Vehicle(RoadObject):
     def lane_offset(self) -> np.ndarray:
         if self.lane is not None:
             long, lat = self.lane.local_coordinates(self.position)
-            return np.array([long, lat])
+            ang = self.lane.local_angle(self.heading, long)
+            return np.array([long, lat, ang])
         else:
-            return np.zeros((2,))
+            return np.zeros((3,))
 
     def to_dict(self, origin_vehicle: "Vehicle" = None, observe_intentions: bool = True) -> dict:
         d = {
@@ -209,6 +210,7 @@ class Vehicle(RoadObject):
             'sin_d': self.destination_direction[1],
             'long_off': self.lane_offset[0],
             'lat_off': self.lane_offset[1],
+            'ang_off': self.lane_offset[2],
         }
         if not observe_intentions:
             d["cos_d"] = d["sin_d"] = 0

--- a/tests/envs/test_gym.py
+++ b/tests/envs/test_gym.py
@@ -8,6 +8,7 @@ envs = [
     "merge-v0",
     "roundabout-v0",
     "intersection-v0",
+    "intersection-v1",
     "parking-v0",
     "summon-v0",
     "two-way-v0",


### PR DESCRIPTION
Following up on issue #307, I included inside the Kinematic observation space of agents certain offsets to lanes.

Motivation: for continuous agents to learn more robustly to stick to their own lanes, without losing generality.

A follow up to this work could be the creation/adaptation of a test environment with a reward function to showcase the benefits of including this information as part of the observation space input of the agent's network.

I will push one more commit to this request, which will include notes in the documentation of the new features in the Kinematics observation. In the meanwhile, please advise on anything that might be missing from this pull request.

Thank you.