### PR TITLE
BUG FIX: Reward for each agent in intersection

### DIFF
--- a/highway_env/envs/intersection_env.py
+++ b/highway_env/envs/intersection_env.py
@@ -69,7 +69,7 @@ class IntersectionEnv(AbstractEnv):
                / len(self.controlled_vehicles)
 
     def _agent_reward(self, action: int, vehicle: Vehicle) -> float:
-        scaled_speed = utils.lmap(self.vehicle.speed, self.config["reward_speed_range"], [0, 1])
+        scaled_speed = utils.lmap(vehicle.speed, self.config["reward_speed_range"], [0, 1])
         reward = self.config["collision_reward"] * vehicle.crashed \
                  + self.config["high_speed_reward"] * np.clip(scaled_speed, 0, 1)
 


### PR DESCRIPTION
The reward function for multi-agent scenarios was being calculated using the scaled speed of only the first agent being spawned (`self.vehicle` instead of the `vehicle` argument of the method).

