### PR TITLE
Add configure option in reset options

### DIFF
--- a/highway_env/envs/common/abstract.py
+++ b/highway_env/envs/common/abstract.py
@@ -192,6 +192,9 @@ class AbstractEnv(gym.Env):
 
         :return: the observation of the reset state
         """
+        if options and "config" in options:
+            self.configure(options["config"])
+
         self.update_metadata()
         self.define_spaces()  # First, to set the controlled vehicle class depending on action space
         self.time = self.steps = 0


### PR DESCRIPTION
Addresses the issue https://github.com/eleurent/highway-env/issues/388

I have chosen to use the built-in `self.configure` function to keep backward compatibility.
