### PR TITLE
Add registration entry point

### DIFF
--- a/highway_env/__init__.py
+++ b/highway_env/__init__.py
@@ -1,5 +1,103 @@
 # Hide pygame support prompt
 import os
 os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = '1'
-# Import the envs module so that envs register themselves
-import highway_env.envs
+
+
+from gym.envs.registration import register
+
+
+def register_highway_envs():
+    """Import the envs module so that envs register themselves."""
+
+    # exit_env.py
+    register(
+        id='exit-v0',
+        entry_point='highway_env.envs:ExitEnv',
+    )
+
+    # highway_env.py
+    register(
+        id='highway-v0',
+        entry_point='highway_env.envs:HighwayEnv',
+    )
+
+    register(
+        id='highway-fast-v0',
+        entry_point='highway_env.envs:HighwayEnvFast',
+    )
+
+    # intersection_env.py
+    register(
+        id='intersection-v0',
+        entry_point='highway_env.envs:IntersectionEnv',
+    )
+
+    register(
+        id='intersection-v1',
+        entry_point='highway_env.envs:ContinuousIntersectionEnv',
+    )
+
+    register(
+        id='intersection-multi-agent-v0',
+        entry_point='highway_env.envs:MultiAgentIntersectionEnv',
+    )
+
+    register(
+        id='intersection-multi-agent-v1',
+        entry_point='highway_env.envs:TupleMultiAgentIntersectionEnv',
+    )
+
+    # lane_keeping_env.py
+    register(
+        id='lane-keeping-v0',
+        entry_point='highway_env.envs:LaneKeepingEnv',
+        max_episode_steps=200
+    )
+
+    # merge_env.py
+    register(
+        id='merge-v0',
+        entry_point='highway_env.envs:MergeEnv',
+    )
+
+    # parking_env.py
+    register(
+        id='parking-v0',
+        entry_point='highway_env.envs:ParkingEnv',
+    )
+
+    register(
+        id='parking-ActionRepeat-v0',
+        entry_point='highway_env.envs:ParkingEnvActionRepeat'
+    )
+
+    register(
+        id='parking-parked-v0',
+        entry_point='highway_env.envs:ParkingEnvParkedVehicles'
+    )
+
+    # racetrack_env.py
+    register(
+        id='racetrack-v0',
+        entry_point='highway_env.envs:RacetrackEnv',
+    )
+
+    # roundabout_env.py
+    register(
+        id='roundabout-v0',
+        entry_point='highway_env.envs:RoundaboutEnv',
+    )
+
+    # two_way_env.py
+    register(
+        id='two-way-v0',
+        entry_point='highway_env.envs:TwoWayEnv',
+        max_episode_steps=15
+    )
+
+    # u_turn_env.py
+    register(
+        id='u-turn-v0',
+        entry_point='highway_env.envs:UTurnEnv'
+    )
+

--- a/highway_env/envs/exit_env.py
+++ b/highway_env/envs/exit_env.py
@@ -1,6 +1,5 @@
 import numpy as np
 from typing import Tuple, Dict, Text
-from gym.envs.registration import register
 
 from highway_env import utils
 from highway_env.envs import HighwayEnv, CircularLane, Vehicle
@@ -151,10 +150,3 @@ class ExitEnv(HighwayEnv):
 #         return dict(super().default_config(),
 #                     observation=dict(type="LidarObservation"))
 
-
-
-
-register(
-    id='exit-v0',
-    entry_point='highway_env.envs:ExitEnv',
-)

--- a/highway_env/envs/highway_env.py
+++ b/highway_env/envs/highway_env.py
@@ -1,7 +1,6 @@
 from typing import Dict, Text
 
 import numpy as np
-from gym.envs.registration import register
 
 from highway_env import utils
 from highway_env.envs.common.abstract import AbstractEnv
@@ -147,14 +146,3 @@ class HighwayEnvFast(HighwayEnv):
         for vehicle in self.road.vehicles:
             if vehicle not in self.controlled_vehicles:
                 vehicle.check_collisions = False
-
-
-register(
-    id='highway-v0',
-    entry_point='highway_env.envs:HighwayEnv',
-)
-
-register(
-    id='highway-fast-v0',
-    entry_point='highway_env.envs:HighwayEnvFast',
-)

--- a/highway_env/envs/intersection_env.py
+++ b/highway_env/envs/intersection_env.py
@@ -1,6 +1,5 @@
 from typing import Dict, Tuple, Text
 
-from gym.envs.registration import register
 import numpy as np
 
 from highway_env import utils
@@ -308,24 +307,3 @@ class ContinuousIntersectionEnv(IntersectionEnv):
         return config
 
 TupleMultiAgentIntersectionEnv = MultiAgentWrapper(MultiAgentIntersectionEnv)
-
-
-register(
-    id='intersection-v0',
-    entry_point='highway_env.envs:IntersectionEnv',
-)
-
-register(
-    id='intersection-v1',
-    entry_point='highway_env.envs:ContinuousIntersectionEnv',
-)
-
-register(
-    id='intersection-multi-agent-v0',
-    entry_point='highway_env.envs:MultiAgentIntersectionEnv',
-)
-
-register(
-    id='intersection-multi-agent-v1',
-    entry_point='highway_env.envs:TupleMultiAgentIntersectionEnv',
-)

--- a/highway_env/envs/lane_keeping_env.py
+++ b/highway_env/envs/lane_keeping_env.py
@@ -4,7 +4,6 @@ import copy
 from typing import Tuple
 
 import numpy as np
-from gym.envs.registration import register
 
 from highway_env.envs.common.abstract import AbstractEnv
 from highway_env.road.lane import LineType, SineLane, StraightLane
@@ -149,10 +148,3 @@ class LaneKeepingEnv(AbstractEnv):
                 interval.append(state.squeeze(-1).copy())
             self.interval_trajectory.append(interval)
         self.trajectory.append(copy.deepcopy(self.vehicle.state))
-
-
-register(
-    id='lane-keeping-v0',
-    entry_point='highway_env.envs:LaneKeepingEnv',
-    max_episode_steps=200
-)

--- a/highway_env/envs/merge_env.py
+++ b/highway_env/envs/merge_env.py
@@ -1,7 +1,6 @@
 from typing import Dict, Text
 
 import numpy as np
-from gym.envs.registration import register
 
 from highway_env import utils
 from highway_env.envs.common.abstract import AbstractEnv
@@ -126,9 +125,3 @@ class MergeEnv(AbstractEnv):
         merging_v.target_speed = 30
         road.vehicles.append(merging_v)
         self.vehicle = ego_vehicle
-
-
-register(
-    id='merge-v0',
-    entry_point='highway_env.envs:MergeEnv',
-)

--- a/highway_env/envs/parking_env.py
+++ b/highway_env/envs/parking_env.py
@@ -1,6 +1,5 @@
 from abc import abstractmethod
 from gym import Env
-from gym.envs.registration import register
 import numpy as np
 
 from highway_env.envs.common.abstract import AbstractEnv
@@ -227,19 +226,3 @@ class ParkingEnvActionRepeat(ParkingEnv):
 class ParkingEnvParkedVehicles(ParkingEnv):
     def __init__(self):
         super().__init__({"vehicles_count": 10})
-
-
-register(
-    id='parking-v0',
-    entry_point='highway_env.envs:ParkingEnv',
-)
-
-register(
-    id='parking-ActionRepeat-v0',
-    entry_point='highway_env.envs:ParkingEnvActionRepeat'
-)
-
-register(
-    id='parking-parked-v0',
-    entry_point='highway_env.envs:ParkingEnvParkedVehicles'
-)

--- a/highway_env/envs/racetrack_env.py
+++ b/highway_env/envs/racetrack_env.py
@@ -1,7 +1,6 @@
 from itertools import repeat, product
 from typing import Tuple, Dict, Text
 
-from gym.envs.registration import register
 import numpy as np
 
 from highway_env import utils
@@ -224,9 +223,3 @@ class RacetrackEnv(AbstractEnv):
                     break
             else:
                 self.road.vehicles.append(vehicle)
-
-
-register(
-    id='racetrack-v0',
-    entry_point='highway_env.envs:RacetrackEnv',
-)

--- a/highway_env/envs/roundabout_env.py
+++ b/highway_env/envs/roundabout_env.py
@@ -1,6 +1,5 @@
 from typing import Tuple, Dict, Text
 
-from gym.envs.registration import register
 import numpy as np
 
 from highway_env import utils
@@ -188,9 +187,3 @@ class RoundaboutEnv(AbstractEnv):
         vehicle.plan_route_to(self.np_random.choice(destinations))
         vehicle.randomize_behavior()
         self.road.vehicles.append(vehicle)
-
-
-register(
-    id='roundabout-v0',
-    entry_point='highway_env.envs:RoundaboutEnv',
-)

--- a/highway_env/envs/two_way_env.py
+++ b/highway_env/envs/two_way_env.py
@@ -1,7 +1,6 @@
 from typing import Dict, Text
 
 import numpy as np
-from gym.envs.registration import register
 
 from highway_env import utils
 from highway_env.envs.common.abstract import AbstractEnv
@@ -116,10 +115,3 @@ class TwoWayEnv(AbstractEnv):
                               enable_lane_change=False)
             v.target_lane_index = ("b", "a", 0)
             self.road.vehicles.append(v)
-
-
-register(
-    id='two-way-v0',
-    entry_point='highway_env.envs:TwoWayEnv',
-    max_episode_steps=15
-)

--- a/highway_env/envs/u_turn_env.py
+++ b/highway_env/envs/u_turn_env.py
@@ -1,7 +1,6 @@
 from typing import Dict, Text
 
 import numpy as np
-from gym.envs.registration import register
 
 
 from highway_env import utils
@@ -206,7 +205,4 @@ class UTurnEnv(AbstractEnv):
         self.road.vehicles.append(vehicle)
 
 
-register(
-    id='u-turn-v0',
-    entry_point='highway_env.envs:UTurnEnv'
-)
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,9 @@ exclude =
     docs
     scripts
 
+[options.entry_points]
+gym.envs =
+    __root__ = highway_env.__init__:register_highway_envs
 
 [aliases]
 test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+# Following PEP 517/518, this file should not not needed and replaced instead by the setup.cfg file and pyproject.toml.
+# Unfortunately it is still required py the pip editable mode `pip install -e`
+# See https://stackoverflow.com/a/60885212
+
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup()

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,0 @@
-# Following PEP 517/518, this file should not not needed and replaced instead by the setup.cfg file and pyproject.toml.
-# Unfortunately it is still required py the pip editable mode `pip install -e`
-# See https://stackoverflow.com/a/60885212
-
-from setuptools import setup
-
-if __name__ == "__main__":
-    setup()


### PR DESCRIPTION
When implementing https://github.com/eleurent/highway-env/pull/389, I noticed that `import highway_envs` was required for registering all of the environments. 
This is quite annoying and pycharm raises this as a unnecessary import.

This PR adds a little-known feature in Gym called entry points that allows during `import gym` for environments to be registered in the background. 
Therefore, users can now run
```python
import gym

env = gym.make("highway-v0")
```
This feature has already been added to https://github.com/farama-Foundation/minigrid if you want to see a similar project with this feature.

Warning, I found for development this can cause issue if the project is not installed in editable mode as the entry point is not loaded or if running in the projects root folder then warnings are raised saying the environment are registered twice. 
However, this shouldn't be an issue for a majority of users 