### PR TITLE
Update branch of pypi-publish in the release.yml worfklow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build package
         run: python setup.py sdist bdist_wheel
       - name: Upload package
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Their master branch has been sunset: https://github.com/marketplace/actions/pypi-publish#-master-branch-sunset-