### PR TITLE
Fix incorrect coordinate transformation in spline

### DIFF
--- a/highway_env/road/spline.py
+++ b/highway_env/road/spline.py
@@ -59,16 +59,13 @@ class LinearSpline2D:
             lat = pose.project_onto_orthonormal(position)
             return lon, lat
 
-        for idx in list(range(len(self.s_samples) - 1))[::-1]:
+        for idx in list(range(1, len(self.s_samples) - 1))[::-1]:
             pose = self.poses[idx]
             projection = pose.project_onto_normal(position)
             if projection >= 0:
-                if projection < pose.distance_to_origin(position):
-                    lon = self.s_samples[idx] + projection
-                    lat = pose.project_onto_orthonormal(position)
-                    return lon, lat
-                else:
-                    ValueError("No valid projection could be found")
+                lon = self.s_samples[idx] + projection
+                lat = pose.project_onto_orthonormal(position)
+                return lon, lat
         pose = self.poses[0]
         lon = pose.project_onto_normal(position)
         lat = pose.project_onto_orthonormal(position)


### PR DESCRIPTION
The coordinate transformation from Cartesian to Frenet in spline seems to have some incorrect output when the point is exactly on the spline. Here's the code for reproducing this issue:
```from highway_env.road.spline import LinearSpline2D
spline = LinearSpline2D([(0, 0), (1, 0), (2, 0.5)])

# Find two very close points, the first is exactly lying on the
# spline, and the second is slightly offset by 0.0001
coor1 = spline.cartesian_to_frenet((1.5, 0.25))
coor2 = spline.cartesian_to_frenet((1.5, 0.25+0.0001))

# The following code prints (np.float64(1.5), np.float64(0.25)),
# which is incorrect as the lateral distance should be 0 (got 0.25 instead), because this point lies on the spline.
print(coor1)

# prints (np.float64(1.5590617157344975), np.float64(8.944271909994139e-05))
# A small deviation should not have such large error for lateral distance.
print(coor2)
```
This PR provides fix and optimization of the coordinate transform to solve the issue.