### PR TITLE
Fix SubprocVecEnv ConnectionResetError with forkserver/spawn

### DIFF
--- a/highway_env/__init__.py
+++ b/highway_env/__init__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from gymnasium.envs.registration import register
+from gymnasium.envs.registration import register, registry
 
 
 __version__ = "1.10.2"
@@ -20,7 +20,15 @@ os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
 
 
 def _register_highway_envs():
-    """Import the envs module so that envs register themselves."""
+    """Import the envs module so that envs register themselves.
+
+    This function is idempotent: calling it multiple times (e.g. when
+    gymnasium resolves a ``"highway_env:env-id"`` spec in a subprocess)
+    will not raise duplicate-registration errors.
+    """
+    # Skip if environments are already registered (idempotent)
+    if "highway-v0" in registry:
+        return
 
     from highway_env.envs.common.abstract import MultiAgentWrapper
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ Repository = "https://github.com/eleurent/highway-env"
 Documentation = "https://highway-env.farama.org/"
 "Bug Report" = "https://github.com/eleurent/highway-env/issues"
 
+[project.entry-points."gymnasium.envs.__root__"]
+highway-env = "highway_env:_register_highway_envs"
+
 [tool.setuptools]
 include-package-data = true
 

--- a/tests/envs/test_multiprocessing.py
+++ b/tests/envs/test_multiprocessing.py
@@ -1,0 +1,59 @@
+"""Test that highway-env environments work with multiprocessing (forkserver/spawn).
+
+When using SubprocVecEnv from stable-baselines3 or similar vectorized
+environment wrappers, child processes are started via ``forkserver`` or
+``spawn`` and do **not** inherit the parent's ``import highway_env``.
+
+Gymnasium's ``module:env_name`` syntax (e.g. ``"highway_env:highway-v0"``)
+triggers an import of the module in the subprocess, which registers the
+environments on demand.
+
+See: https://github.com/Farama-Foundation/HighwayEnv/issues/648
+"""
+
+import multiprocessing as mp
+
+import gymnasium as gym
+import pytest
+
+
+def _make_env_in_subprocess(env_id: str, result_queue: mp.Queue) -> None:
+    """Create and step an environment inside a subprocess (no prior import of highway_env)."""
+    try:
+        env = gym.make(env_id)
+        obs, _info = env.reset()
+        _obs, _reward, _terminated, _truncated, _info = env.step(
+            env.action_space.sample()
+        )
+        env.close()
+        result_queue.put(("ok", str(type(obs))))
+    except Exception as exc:
+        result_queue.put(("error", f"{type(exc).__name__}: {exc}"))
+
+
+@pytest.mark.parametrize(
+    "env_id",
+    [
+        "highway_env:highway-v0",
+        "highway_env:highway-fast-v0",
+        "highway_env:merge-v0",
+        "highway_env:roundabout-v0",
+        "highway_env:intersection-v0",
+        "highway_env:parking-v0",
+    ],
+)
+@pytest.mark.parametrize("start_method", ["forkserver", "spawn"])
+def test_env_in_subprocess(env_id: str, start_method: str) -> None:
+    """Environments should be creatable in forkserver/spawn subprocesses via module:name syntax."""
+    if start_method not in mp.get_all_start_methods():
+        pytest.skip(f"{start_method} not available on this platform")
+
+    ctx = mp.get_context(start_method)
+    q: mp.Queue = ctx.Queue()
+    p = ctx.Process(target=_make_env_in_subprocess, args=(env_id, q))
+    p.start()
+    p.join(timeout=30)
+
+    assert not q.empty(), "Subprocess produced no result (likely crashed)"
+    status, detail = q.get()
+    assert status == "ok", f"Subprocess failed: {detail}"


### PR DESCRIPTION
## Summary

Fix `ConnectionResetError: [Errno 104] Connection reset by peer` when creating highway-env environments via `SubprocVecEnv` (stable-baselines3) or any multiprocessing wrapper that uses the `forkserver`/`spawn` start method.

**Root cause:** `SubprocVecEnv` defaults to `forkserver` when available. Child processes started via `forkserver` or `spawn` do **not** inherit the parent's `import highway_env`, so `gymnasium.register()` calls in `highway_env/__init__.py` never execute in the subprocess. When `gym.make("highway-fast-v0")` runs in the child, the environment is not in the registry → `NameNotFound` → subprocess crash → `ConnectionResetError` in the parent.

**Fix:**
- Make `_register_highway_envs()` **idempotent** (skip if already registered) so that re-importing `highway_env` via gymnasium's `module:env_name` resolution does not raise duplicate-registration errors
- Add a **gymnasium entry-point** in `pyproject.toml` for potential future auto-discovery
- Users should use `gym.make("highway_env:highway-fast-v0")` (with module prefix) when using `SubprocVecEnv` — gymnasium's `_find_spec` imports the module in the subprocess before looking up the environment

Fixes #648

<details>
<summary>Before</summary>

```
=== Using bare env ID with SubprocVecEnv ===

Process ForkServerProcess-1:
Traceback (most recent call last):
  File "multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "stable_baselines3/common/vec_env/subproc_vec_env.py", line 29, in _worker
    env = _patch_env(env_fn_wrapper.var())
  File "stable_baselines3/common/env_util.py", line 95, in _init
    env = gym.make(env_id, **kwargs)
  File "gymnasium/envs/registration.py", line 681, in make
    env_spec = _find_spec(id)
  File "gymnasium/envs/registration.py", line 526, in _find_spec
    _check_version_exists(ns, name, version)
  File "gymnasium/envs/registration.py", line 392, in _check_version_exists
    _check_name_exists(ns, name)
  File "gymnasium/envs/registration.py", line 369, in _check_name_exists
    raise error.NameNotFound(
gymnasium.error.NameNotFound: Environment `highway-fast` doesn't exist.
Process ForkServerProcess-2:
Traceback (most recent call last):
  ...
gymnasium.error.NameNotFound: Environment `highway-fast` doesn't exist.

ConnectionResetError: [Errno 104] Connection reset by peer
```

</details>

<details>
<summary>After</summary>

```
=== Using module:env_name syntax with SubprocVecEnv ===

gymnasium supports "module:env_name" syntax which imports the module
in the subprocess before looking up the environment.

SubprocVecEnv created: obs shape=(2, 5, 5)
5 steps completed successfully
Environment closed cleanly

SUCCESS: No ConnectionResetError!
```

```
============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0

tests/envs/test_multiprocessing.py::test_env_in_subprocess[forkserver-highway_env:highway-v0] PASSED
tests/envs/test_multiprocessing.py::test_env_in_subprocess[forkserver-highway_env:highway-fast-v0] PASSED
tests/envs/test_multiprocessing.py::test_env_in_subprocess[forkserver-highway_env:merge-v0] PASSED
tests/envs/test_multiprocessing.py::test_env_in_subprocess[forkserver-highway_env:roundabout-v0] PASSED
tests/envs/test_multiprocessing.py::test_env_in_subprocess[forkserver-highway_env:intersection-v0] PASSED
tests/envs/test_multiprocessing.py::test_env_in_subprocess[forkserver-highway_env:parking-v0] PASSED
tests/envs/test_multiprocessing.py::test_env_in_subprocess[spawn-highway_env:highway-v0] PASSED
tests/envs/test_multiprocessing.py::test_env_in_subprocess[spawn-highway_env:highway-fast-v0] PASSED
tests/envs/test_multiprocessing.py::test_env_in_subprocess[spawn-highway_env:merge-v0] PASSED
tests/envs/test_multiprocessing.py::test_env_in_subprocess[spawn-highway_env:roundabout-v0] PASSED
tests/envs/test_multiprocessing.py::test_env_in_subprocess[spawn-highway_env:intersection-v0] PASSED
tests/envs/test_multiprocessing.py::test_env_in_subprocess[spawn-highway_env:parking-v0] PASSED

============================= 12 passed in 15.11s ==============================

============================= full test suite ==============================
73 passed, 1 skipped, 0 failed in 37.31s
```

</details>

## Test plan
- [x] 12 new multiprocessing tests: `forkserver` and `spawn` × 6 env IDs
- [x] Full test suite: 73 passed, 1 skipped, 0 failed (no regression)
- [x] Manual verification: `SubprocVecEnv` with `stable-baselines3` works end-to-end