### PR TITLE
Add a generic version of the roundabout environment

### DIFF
--- a/highway_env/__init__.py
+++ b/highway_env/__init__.py
@@ -111,6 +111,10 @@ def _register_highway_envs():
         id="roundabout-v0",
         entry_point="highway_env.envs.roundabout_env:RoundaboutEnv",
     )
+    register(
+        id="roundabout-generic-v0",
+        entry_point="highway_env.envs.roundabout_env:RoundaboutGenericEnv",
+    )
 
     # two_way_env.py
     register(

--- a/highway_env/envs/roundabout_env.py
+++ b/highway_env/envs/roundabout_env.py
@@ -385,3 +385,355 @@ class RoundaboutEnv(AbstractEnv):
         vehicle.plan_route_to(self.np_random.choice(destinations))
         vehicle.randomize_behavior()
         self.road.vehicles.append(vehicle)
+
+
+class RoundaboutGenericEnv(RoundaboutEnv):
+    """
+    A generic version of the roundabout environment.
+    Additionally supports changing:
+    - the number of lanes in the roundabout
+    - the roundabout radius
+    - the number of spawned other vehicles
+    """
+
+    @classmethod
+    def default_config(cls) -> dict:
+        config = super().default_config()
+        config.update(
+            {
+                "roundabout_radius": 20,
+                "roundabout_lanes": 2,
+                "vehicles_count": 5,
+                "duration": 17,
+            }
+        )
+        return config
+
+    def _make_road(self) -> None:
+        center = [0, 0]  # [m]
+        radius = self.config["roundabout_radius"]
+        num_lanes = self.config["roundabout_lanes"]
+        alpha = 24  # [deg]
+
+        net = RoadNetwork()
+        radii = [radius + (4 * i) for i in range(num_lanes)]
+        n, c, s = LineType.NONE, LineType.CONTINUOUS, LineType.STRIPED
+
+        nodes = ["se", "ex", "ee", "nx", "ne", "wx", "we", "sx", "se"]
+
+        angles = [
+            (90 - alpha, alpha),
+            (alpha, -alpha),
+            (-alpha, -90 + alpha),
+            (-90 + alpha, -90 - alpha),
+            (-90 - alpha, -180 + alpha),
+            (-180 + alpha, -180 - alpha),
+            (180 - alpha, 90 + alpha),
+            (90 + alpha, 90 - alpha),
+        ]
+
+        for lane in range(num_lanes):
+            if num_lanes == 1:
+                line_types = [c, c]
+            elif lane == 0:
+                line_types = [c, s]
+            elif lane == num_lanes - 1:
+                line_types = [n, c]
+            else:
+                line_types = [n, s]
+
+            for i in range(8):
+                net.add_lane(
+                    nodes[i],
+                    nodes[i + 1],
+                    CircularLane(
+                        center,
+                        radii[lane],
+                        np.deg2rad(angles[i][0]),
+                        np.deg2rad(angles[i][1]),
+                        clockwise=False,
+                        line_types=line_types,
+                    ),
+                )
+
+        # Dynamically calculate exact coordinates on the outermost circle
+        outer_radius = radii[-1]
+
+        def pt(angle_deg: float) -> list[float]:
+            rad = np.deg2rad(angle_deg)
+            return [outer_radius * np.cos(rad), outer_radius * np.sin(rad)]
+
+        p_se = pt(90 - alpha)
+        p_ex = pt(alpha)
+        p_ee = pt(-alpha)
+        p_nx = pt(-90 + alpha)
+        p_ne = pt(-90 - alpha)
+        p_wx = pt(-180 + alpha)
+        p_we = pt(180 - alpha)
+        p_sx = pt(90 + alpha)
+
+        # In case radius is very large
+        dev = max(100.0, 2 * outer_radius + 40.0)
+        access = dev + 40.0
+
+        # South Entry (ses -> se)
+        dy = dev / 2 - p_se[1]
+        a = (p_se[0] - 2) / 2
+        w = np.pi / dy
+        net.add_lane(
+            "ser",
+            "ses",
+            StraightLane([2, access], [2, dev / 2], line_types=(s, c)),
+        )
+        net.add_lane(
+            "ses",
+            "se",
+            SineLane(
+                [2 + a, dev / 2], [2 + a, p_se[1]], a, w, -np.pi / 2, line_types=(c, c)
+            ),
+        )
+
+        # South Exit (sx -> sxs)
+        dy = dev / 2 - p_sx[1]
+        a = (p_sx[0] + 2) / 2
+        w = np.pi / dy
+        net.add_lane(
+            "sx",
+            "sxs",
+            SineLane(
+                [p_sx[0] - a, p_sx[1]],
+                [p_sx[0] - a, dev / 2],
+                a,
+                w,
+                -np.pi / 2,
+                line_types=(c, c),
+            ),
+        )
+        net.add_lane(
+            "sxs",
+            "sxr",
+            StraightLane([-2, dev / 2], [-2, access], line_types=(n, c)),
+        )
+
+        # East Entry (ees -> ee)
+        dx = dev / 2 - p_ee[0]
+        a = (-2 - p_ee[1]) / 2
+        w = np.pi / dx
+        net.add_lane(
+            "eer",
+            "ees",
+            StraightLane([access, -2], [dev / 2, -2], line_types=(s, c)),
+        )
+        net.add_lane(
+            "ees",
+            "ee",
+            SineLane(
+                [dev / 2, -2 - a],
+                [p_ee[0], -2 - a],
+                a,
+                w,
+                -np.pi / 2,
+                line_types=(c, c),
+            ),
+        )
+
+        # East Exit (ex -> exs)
+        dx = dev / 2 - p_ex[0]
+        a = (2 - p_ex[1]) / 2
+        w = np.pi / dx
+        net.add_lane(
+            "ex",
+            "exs",
+            SineLane(
+                [p_ex[0], p_ex[1] + a],
+                [dev / 2, p_ex[1] + a],
+                a,
+                w,
+                -np.pi / 2,
+                line_types=(c, c),
+            ),
+        )
+        net.add_lane(
+            "exs",
+            "exr",
+            StraightLane([dev / 2, 2], [access, 2], line_types=(n, c)),
+        )
+
+        # North Entry (nes -> ne)
+        dy = p_ne[1] - (-dev / 2)
+        a = (-2 - p_ne[0]) / 2
+        w = np.pi / dy
+        net.add_lane(
+            "ner",
+            "nes",
+            StraightLane([-2, -access], [-2, -dev / 2], line_types=(s, c)),
+        )
+        net.add_lane(
+            "nes",
+            "ne",
+            SineLane(
+                [-2 - a, -dev / 2],
+                [-2 - a, p_ne[1]],
+                a,
+                w,
+                -np.pi / 2,
+                line_types=(c, c),
+            ),
+        )
+
+        # North Exit (nx -> nxs)
+        dy = p_nx[1] - (-dev / 2)
+        a = (2 - p_nx[0]) / 2
+        w = np.pi / dy
+        net.add_lane(
+            "nx",
+            "nxs",
+            SineLane(
+                [p_nx[0] + a, p_nx[1]],
+                [p_nx[0] + a, -dev / 2],
+                a,
+                w,
+                -np.pi / 2,
+                line_types=(c, c),
+            ),
+        )
+        net.add_lane(
+            "nxs",
+            "nxr",
+            StraightLane([2, -dev / 2], [2, -access], line_types=(n, c)),
+        )
+
+        # West Entry (wes -> we)
+        dx = p_we[0] - (-dev / 2)
+        a = (p_we[1] - 2) / 2
+        w = np.pi / dx
+        net.add_lane(
+            "wer",
+            "wes",
+            StraightLane([-access, 2], [-dev / 2, 2], line_types=(s, c)),
+        )
+        net.add_lane(
+            "wes",
+            "we",
+            SineLane(
+                [-dev / 2, 2 + a], [p_we[0], 2 + a], a, w, -np.pi / 2, line_types=(c, c)
+            ),
+        )
+
+        # West Exit (wx -> wxs)
+        dx = p_wx[0] - (-dev / 2)
+        a = (p_wx[1] + 2) / 2
+        w = np.pi / dx
+        net.add_lane(
+            "wx",
+            "wxs",
+            SineLane(
+                [p_wx[0], p_wx[1] - a],
+                [-dev / 2, p_wx[1] - a],
+                a,
+                w,
+                -np.pi / 2,
+                line_types=(c, c),
+            ),
+        )
+        net.add_lane(
+            "wxs",
+            "wxr",
+            StraightLane([-dev / 2, -2], [-access, -2], line_types=(n, c)),
+        )
+
+        road = Road(
+            network=net,
+            np_random=self.np_random,
+            record_history=self.config["show_trajectories"],
+        )
+        self.road = road
+
+    def _make_vehicles(self) -> None:
+        speed_deviation = 2.0
+        vehicle_count = self.config["vehicles_count"]
+        other_vehicles_type = utils.class_from_path(self.config["other_vehicles_type"])
+        destinations = ["exr", "sxr", "nxr", "wxr"]
+
+        ego_lane_id = ("ser", "ses", 0)
+        ego_lane = self.road.network.get_lane(ego_lane_id)
+        ego_longitudinal = ego_lane.length - 2.5  # Placed at end of straight lane
+
+        ego_vehicle = self.action_type.vehicle_class(
+            self.road,
+            ego_lane.position(ego_longitudinal, 0.0),
+            speed=8.0,
+            heading=ego_lane.heading_at(ego_longitudinal),
+        )
+        try:
+            ego_vehicle.plan_route_to("nxs")
+        except AttributeError:
+            pass
+        self.road.vehicles.append(ego_vehicle)
+        self.vehicle = ego_vehicle
+
+        spawned_positions = {}
+        spawned_positions[ego_lane_id] = [ego_longitudinal]
+
+        spawn_lanes = [
+            ("we", "sx"),
+            ("sx", "se"),
+            ("ee", "nx"),
+            ("nx", "ne"),
+            ("eer", "ees"),
+            ("ner", "nes"),
+            ("wer", "wes"),
+        ]
+
+        spawned_points = []
+        spawned_points.append(ego_lane.position(ego_longitudinal, 0.0))
+        safe_distance = 7.0  # safe distance to spawn vehicles from each other
+        tries = 10  # number of times it tries to spawn a vehicle
+        for _ in range(vehicle_count):
+            for _ in range(tries):
+                lane_tuple = spawn_lanes[self.np_random.integers(0, len(spawn_lanes))]
+                available_lanes = len(
+                    self.road.network.graph[lane_tuple[0]][lane_tuple[1]]
+                )
+                lane_index = self.np_random.integers(0, available_lanes)
+                lane_id = (lane_tuple[0], lane_tuple[1], lane_index)
+
+                lane = self.road.network.get_lane(lane_id)
+                longitudinal = self.np_random.uniform(
+                    5.0,
+                    max(5.0, lane.length - 5.0),
+                )
+
+                candidate_position = lane.position(longitudinal, 0.0)
+
+                is_safe = True
+                for point in spawned_points:
+                    if np.linalg.norm(candidate_position - point) < safe_distance:
+                        is_safe = False
+                        break
+
+                if is_safe:
+                    vehicle = other_vehicles_type.make_on_lane(
+                        self.road,
+                        lane_id,
+                        longitudinal=longitudinal,
+                        speed=14.0 + self.np_random.normal() * speed_deviation,
+                    )
+
+                    if self.config.get("incoming_vehicle_destination") is not None:
+                        dest_idx = min(
+                            self.config["incoming_vehicle_destination"],
+                            len(destinations) - 1,
+                        )
+                        destination = destinations[dest_idx]
+                    else:
+                        destination = destinations[
+                            self.np_random.integers(0, len(destinations))
+                        ]
+
+                    vehicle.plan_route_to(destination)
+                    vehicle.randomize_behavior()
+                    self.road.vehicles.append(vehicle)
+
+                    spawned_points.append(candidate_position)
+                    break


### PR DESCRIPTION

## Summary
This PR adds a new version of the roundabout environment, a class called `RoundaboutGenericEnv`, registered as `roundabout-generic-v0`, with configurable parameters:
- Number of the roundabout lanes
- Radius of the roundabout
- Number of spawned other vehicles

Here are two different configurations:
| `config={"roundabout_lanes": 2, "roundabout_radius": 20, "vehicles_count": 5}` (default) | `config={"roundabout_lanes": 4, "roundabout_radius": 40, "vehicles_count": 15}`|
|:-:|:-:|
| <img width="598" height="599" alt="default config image" src="https://github.com/user-attachments/assets/936ee2a8-823d-4a9e-914f-bb47b22d6423" /> | <img width="598" height="599" alt="larger roundabout image" src="https://github.com/user-attachments/assets/354e0dad-b292-4d7d-b131-9f55ebeaa89d" /> |

## Context
I wanted to have some configurable options for several highway-env environments, and ended up making a more generic version of the roundabout.

I'm open to make requested changes to the environment. If this version is useful, I have also made a similar "generic" version for the merge environment.