### PR TITLE
ci: bump docs workflows from Python 3.9 to 3.11

### DIFF
--- a/.github/workflows/build-docs-dev.yml
+++ b/.github/workflows/build-docs-dev.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.9'
+            python-version: '3.11'
 
       - name: Install dependencies
         run: pip install -r docs/requirements.txt

--- a/.github/workflows/build-docs-version.yml
+++ b/.github/workflows/build-docs-version.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.9'
+            python-version: '3.11'
 
       - name: Get tag
         id: tag

--- a/.github/workflows/manual-build-docs-version.yml
+++ b/.github/workflows/manual-build-docs-version.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.9'
+            python-version: '3.11'
 
       - name: Install dependencies
         run: pip install -r docs/requirements.txt


### PR DESCRIPTION
## Summary

- The package requires `python >= 3.10` (`pyproject.toml`), but `build-docs-dev.yml`, `build-docs-version.yml`, and `manual-build-docs-version.yml` pin Python 3.9. Their `pip install -e .` step fails with:

  ```
  ERROR: Package 'highway-env' requires a different Python:
  3.9.25 not in '>=3.10'
  ```

- Bumps all three docs workflows to Python 3.11 (matches `release.yml`'s 3.12 and falls in the 3.10–3.13 matrix used by `build.yml`).