### PR TITLE
[Chore] Migrate to pygame-ce

### DIFF
--- a/highway_env/__init__.py
+++ b/highway_env/__init__.py
@@ -9,7 +9,7 @@ __version__ = "1.11"
 try:
     from farama_notifications import notifications
 
-    if "highway_env" in notifications and __version__ in notifications["gymnasium"]:
+    if "highway_env" in notifications and __version__ in notifications["highway_env"]:
         print(notifications["highway_env"][__version__], file=sys.stderr)
 
 except Exception:  # nosec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "gymnasium >=1.0.0a2",
     "farama-notifications >=0.0.1",
     "numpy >=1.23.0",
-    "pygame-ce >=2.5.5",
+    "pygame-ce >=2.1.3",
     "matplotlib",
     "pandas",
     "scipy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "gymnasium >=1.0.0a2",
     "farama-notifications >=0.0.1",
     "numpy >=1.23.0",
-    "pygame >=2.0.2",
+    "pygame-ce >=2.5.5",
     "matplotlib",
     "pandas",
     "scipy"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ CWD = pathlib.Path(__file__).absolute().parent
 
 
 def get_version():
-    """Gets the gymnasium version."""
+    """Gets the highway-env version."""
     path = CWD / "highway_env" / "__init__.py"
     content = path.read_text()
 


### PR DESCRIPTION
### Description
The original [pygame](https://github.com/pygame/pygame) project has not been well maintained in recent years, with latest release version [2.6.1](https://github.com/pygame/pygame/releases/tag/2.6.1) published in Sep 2024 providing only prebuilt wheels for up to Python 3.13. A well-maintained fork - [pygame-ce](https://github.com/pygame-community/pygame-ce) does provide wheels for Python 3.14 and has been adopted by other Farama projects such as Gymnasium (https://github.com/Farama-Foundation/Gymnasium/pull/1512) & ViZDoom (https://github.com/Farama-Foundation/ViZDoom/pull/653).

With [HighwayEnv v1.11](https://github.com/Farama-Foundation/HighwayEnv/releases/tag/v1.11) adding support for Python 3.14, having one of the core dependencies requiring source installation is undesirable for downstream users. Starting from [2.5.5](https://github.com/pygame-community/pygame-ce/releases/tag/2.5.5), pygame-ce provide wheels for Python 3.9 - 3.14, aligning with HighwayEnv's requirement.

Also fixed two minor bugs where `gymnasium` is used instead of `highway_env`.

### Type of change
- [x] Compatibility fix

### Checklist
- [x] I have ensured all unit tests have passed
- [x] I have done basic end-to-end testing to ensure `"human"` render mode works as intended.