### PR TITLE
[CI] Update All GitHub Action Workflows That Relied on Renamed "master" Branch

### DIFF
--- a/.github/workflows/build-docs-dev.yml
+++ b/.github/workflows/build-docs-dev.yml
@@ -1,7 +1,7 @@
 name: Build main branch documentation website
 on:
   push:
-    branches: [master]
+    branches: [main]
 permissions:
   contents: write
 env:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,7 +4,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read # to fetch code (actions/checkout)


### PR DESCRIPTION
# Description

Two GitHub Actions workflows would only run on the `master` branch, which has been renamed to `main`:
- `.github/workflows/build-docs-dev.yml`
- `.github/workflows/pre-commit.yml`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
