### PR TITLE
[Perf] Initialize Only Required Modules of pygame

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Submit a bug report
-title: "[Bug Report] Bug title"
+title: "[Bug] Bug title"
 labels: ["bug"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/perf.yml
+++ b/.github/ISSUE_TEMPLATE/perf.yml
@@ -1,0 +1,77 @@
+name: Performance
+description: Report a performance issue or propose a performance improvement
+title: "[Performance] Performance title"
+labels: ["performance"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the performance issue
+      description: A clear and concise description of the slowdown, bottleneck, or resource usage problem.
+    validations:
+      required: true
+
+  - type: input
+    id: environment-id
+    attributes:
+      label: Environment ID
+      description: The Gymnasium environment ID (e.g. `highway-v0`, `racetrack-v0`), `*` if not environment-specific, or `N/A` if you are not sure.
+      placeholder: highway-v0
+    validations:
+      required: true
+
+  - type: textarea
+    id: metrics
+    attributes:
+      label: Current vs expected performance
+      description: |
+        Share measurable results where possible (e.g. steps/sec, reset time, render FPS, memory usage, training throughput).
+        Include what you expected and what you observed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: profiling
+    attributes:
+      label: Profiling output, or flame graph that demonstrates the hotspot (if applicable)
+      description: |
+        Share the profiling output, we recommend using `line-profiler` as it's more intuitive to read.
+        For flame graph you can try `pyinstrument -r html -o <output_file> benchmark_script.py`.
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps or benchmark
+      description: |
+        Provide a minimal script, benchmark, or step-by-step instructions to reproduce the performance issue.
+        This will be automatically formatted into code, so no need for backticks.
+      render: python
+
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System info
+      description: |
+        Describe the characteristic of your environment:
+        * Describe how `highway-env` was installed (pip, source, ...)
+        * Version of `highway-env` (e.g. `import highway_env; highway_env.__version__`)
+        * Version of `gymnasium` (e.g. `import gymnasium; gymnasium.__version__`)
+        * Version of `pygame` or `pygame-ce` (e.g. `import pygame; pygame.__version__`)
+        * What OS/version you're using.
+        * Which Python version are you using, is there anything special about it? (e.g. free-thread build, MSYS2/Mingw fork, ...)
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here (profiling output, related issues, screenshots, etc.).
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: >
+            I have checked that there is no similar [issue](https://github.com/Farama-Foundation/HighwayEnv/issues) in
+            the repo
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,7 @@ Fixes # (issue)
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] New environment or environment variant
+- [ ] Performance improvement (non-breaking change that improves speed, memory, or resource usage)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Compatibility fix or other chore tasks
 - [ ] This change requires a documentation update
@@ -39,6 +40,7 @@ To upload images to a PR -- simply drag and drop an image while in edit mode and
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
+- [ ] If my code may add latency, I've tested locally and provided details in description above
 
 <!--
 As you go through the checklist above, you can mark something as done by putting an x character in it

--- a/highway_env/envs/common/graphics.py
+++ b/highway_env/envs/common/graphics.py
@@ -36,7 +36,8 @@ class EnvViewer:
         self.frame = 0
         self.directory = None
 
-        pygame.init()
+        pygame.display.init()
+        pygame.font.init()
         pygame.display.set_caption("Highway-env")
         panel_size = (self.config["screen_width"], self.config["screen_height"])
 


### PR DESCRIPTION
# Description

Profiling shows that this cuts the initialisation time by a lot. The `pygame.font` module is intentionally always initialised, as its startup time seems negligible & we'd rather pay a Python function-call tax at the constructor than in any other methods.

Relevant PRs in other Farama libraries:
- https://github.com/Farama-Foundation/Gymnasium/pull/1586
- https://github.com/Farama-Foundation/PettingZoo/pull/1343

Fixes #686 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Performance improvement (non-breaking change that improves speed, memory, or resource usage)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
