### PR TITLE
perf: remove scipy dependency

### DIFF
--- a/docs/dynamics/road/neighbour_vehicles.md
+++ b/docs/dynamics/road/neighbour_vehicles.md
@@ -91,15 +91,15 @@ Side-by-side comparison of merge-v0 (left) and merge-v1 (right).
 
 A pygame program has been created to demonstrate the difference:
 
-[scripts/compare_neighbour_detection.py](https://github.com/Farama-Foundation/HighwayEnv/blob/main/scripts/compare_neighbour_detection.py)
+[scripts/validate/compare_neighbour_detection.py](https://github.com/Farama-Foundation/HighwayEnv/blob/main/scripts/validate/compare_neighbour_detection.py)
 
 ```bash
-python scripts/compare_neighbour_detection.py
-python scripts/compare_neighbour_detection.py --env merge
-python scripts/compare_neighbour_detection.py --env intersection
-python scripts/compare_neighbour_detection.py --env racetrack-large --no-patch
-python scripts/compare_neighbour_detection.py --validate
-python scripts/compare_neighbour_detection.py --fixed-seed --steps 80
+python scripts/validate/compare_neighbour_detection.py
+python scripts/validate/compare_neighbour_detection.py --env merge
+python scripts/validate/compare_neighbour_detection.py --env intersection
+python scripts/validate/compare_neighbour_detection.py --env racetrack-large --no-patch
+python scripts/validate/compare_neighbour_detection.py --validate
+python scripts/validate/compare_neighbour_detection.py --fixed-seed --steps 80
 ```
 
 | Flag | Description |

--- a/highway_env/road/spline.py
+++ b/highway_env/road/spline.py
@@ -1,7 +1,36 @@
 from __future__ import annotations
 
 import numpy as np
-from scipy import interpolate
+
+
+def numpy_interp1d(x: np.ndarray, y: np.ndarray):
+    """
+    Drop-in replacement for ``scipy.interpolate.interp1d(x, y, fill_value="extrapolate")``.
+
+    Introduced by https://github.com/Farama-Foundation/HighwayEnv/pull/691 to remove the ``scipy`` dependency.
+    A validation benchmark script can be found at ``scripts/validate/bench_interp1d.py``.
+    """
+
+    def interpolator(x_new):
+        x_new = np.asarray(x_new, dtype=float)
+        scalar = x_new.ndim == 0
+        x_new = np.atleast_1d(x_new)
+
+        result = np.interp(x_new, x, y)
+
+        left = x_new < x[0]
+        if np.any(left):
+            slope = (y[1] - y[0]) / (x[1] - x[0])
+            result[left] = y[0] + slope * (x_new[left] - x[0])
+
+        right = x_new > x[-1]
+        if np.any(right):
+            slope = (y[-1] - y[-2]) / (x[-1] - x[-2])
+            result[right] = y[-1] + slope * (x_new[right] - x[-1])
+
+        return float(result[0]) if scalar else result
+
+    return interpolator
 
 
 class LinearSpline2D:
@@ -22,18 +51,10 @@ class LinearSpline2D:
             (0, np.cumsum(np.sqrt(x_values_diff[:-1] ** 2 + y_values_diff[:-1] ** 2)))
         )
         self.length = arc_length_cumulated[-1]
-        self.x_curve = interpolate.interp1d(
-            arc_length_cumulated, x_values, fill_value="extrapolate"
-        )
-        self.y_curve = interpolate.interp1d(
-            arc_length_cumulated, y_values, fill_value="extrapolate"
-        )
-        self.dx_curve = interpolate.interp1d(
-            arc_length_cumulated, x_values_diff, fill_value="extrapolate"
-        )
-        self.dy_curve = interpolate.interp1d(
-            arc_length_cumulated, y_values_diff, fill_value="extrapolate"
-        )
+        self.x_curve = numpy_interp1d(arc_length_cumulated, x_values)
+        self.y_curve = numpy_interp1d(arc_length_cumulated, y_values)
+        self.dx_curve = numpy_interp1d(arc_length_cumulated, x_values_diff)
+        self.dy_curve = numpy_interp1d(arc_length_cumulated, y_values_diff)
 
         (self.s_samples, self.poses) = self.sample_curve(
             self.x_curve, self.y_curve, self.length, self.PARAM_CURVE_SAMPLE_DISTANCE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dynamic = ["version"]
 [project.optional-dependencies]
 testing = [
     "pytest",
-    "pytest-cov"
+    "pytest-cov",
+    "scipy",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "pygame-ce >=2.1.3",
     "matplotlib",
     "pandas",
-    "scipy"
 ]
 dynamic = ["version"]
 

--- a/scripts/regression_test/bench_render_fps.py
+++ b/scripts/regression_test/bench_render_fps.py
@@ -1,0 +1,194 @@
+"""
+Benchmark render-mode FPS across highway-env environments.
+
+Measures wall-clock frames-per-second for three render modes:
+  - None          (headless, no rendering at all)
+  - "rgb_array"   (offscreen rendering, returns pixel buffer)
+  - "human"       (on-screen window rendering)
+
+The first two set OFFSCREEN_RENDERING=1 so pygame never tries to open a display.
+
+Run:
+    uv run python scripts/regression_test/bench_render_fps.py
+    uv run python scripts/regression_test/bench_render_fps.py --envs highway-v0 intersection-v0
+    uv run python scripts/regression_test/bench_render_fps.py --steps 200 --repeat 50
+    uv run python scripts/regression_test/bench_render_fps.py --name my_run
+"""
+
+import argparse
+import json
+import os
+import platform
+import time
+import warnings
+
+import gymnasium as gym
+import numpy as np
+from tqdm.rich import trange
+
+from highway_env import __version__ as env_ver
+
+
+SEED = 42
+DEFAULT_STEPS = 100
+DEFAULT_REPEATS = 100
+RESULTS_DIR = os.path.join(os.path.dirname(__file__), "results")
+DEFAULT_NAME = "bench_render_fps"
+DEFAULT_ENVS = [
+    "highway-v0",
+    "intersection-v0",
+    "roundabout-v0",
+    "merge-v0",
+    "racetrack-v0",
+]
+RENDER_MODES: list[dict] = [
+    {"render_mode": None, "offscreen": True, "label": "None"},
+    {"render_mode": "rgb_array", "offscreen": True, "label": "rgb_array"},
+    {"render_mode": "human", "offscreen": False, "label": "human"},
+]
+
+warnings.filterwarnings("ignore")
+print(f"HighwayEnv Version: {env_ver}")
+os.makedirs(RESULTS_DIR, exist_ok=True)
+
+
+def run_episode(
+    env_id: str,
+    render_mode: str | None,
+    offscreen: bool,
+    n_steps: int,
+    seed: int,
+) -> float:
+    """Run one episode and return elapsed seconds."""
+    env = gym.make(
+        env_id,
+        render_mode=render_mode,
+        config={"offscreen_rendering": offscreen, "real_time_rendering": False},
+    )
+
+    env.reset(seed=seed)
+    action_space = env.action_space
+    action_space.seed(seed)
+
+    t_start = time.perf_counter()
+    for _ in range(n_steps):
+        action = action_space.sample()
+        _obs, _reward, terminated, truncated, _info = env.step(action)
+        if render_mode == "rgb_array":
+            env.render()
+        if terminated or truncated:
+            env.reset(seed=seed)
+    elapsed = time.perf_counter() - t_start
+
+    env.close()
+    time.sleep(1)
+    return elapsed
+
+
+def bench_render_mode(
+    env_id: str,
+    render_mode: str | None,
+    offscreen: bool,
+    n_steps: int,
+    n_repeat: int,
+) -> dict:
+    """Repeat run_episode n_repeat times (seed increments each iter) and return stats."""
+    old_val = os.environ.get("OFFSCREEN_RENDERING")
+    os.environ["OFFSCREEN_RENDERING"] = "1" if offscreen else "0"
+    try:
+        timings = [
+            run_episode(env_id, render_mode, offscreen, n_steps, seed=SEED + i)
+            for i in trange(n_repeat)
+        ]
+    finally:
+        if old_val is None:
+            os.environ.pop("OFFSCREEN_RENDERING", None)
+        else:
+            os.environ["OFFSCREEN_RENDERING"] = old_val
+
+    fps_values = [n_steps / t for t in timings]
+    return {
+        "env": env_id,
+        "render_mode": str(render_mode),
+        "offscreen": offscreen,
+        "steps": n_steps,
+        "n_repeat": n_repeat,
+        "mean_fps": round(float(np.mean(fps_values)), 2),
+        "std_fps": round(float(np.std(fps_values)), 2),
+        "min_fps": round(float(np.min(fps_values)), 2),
+        "max_fps": round(float(np.max(fps_values)), 2),
+        "mean_elapsed_s": round(float(np.mean(timings)), 4),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark render-mode FPS")
+    parser.add_argument(
+        "--envs", nargs="+", default=DEFAULT_ENVS, help="Environment IDs to benchmark"
+    )
+    parser.add_argument(
+        "--steps", type=int, default=DEFAULT_STEPS, help="Steps per episode"
+    )
+    parser.add_argument(
+        "--repeat", type=int, default=DEFAULT_REPEATS, help="Repeats per configuration"
+    )
+    parser.add_argument(
+        "--name", default=DEFAULT_NAME, help="Output filename (without extension)"
+    )
+    args = parser.parse_args()
+
+    result_file = os.path.join(RESULTS_DIR, f"{args.name}.json")
+
+    results: list[dict] = []
+
+    header = (
+        f"{'env':>25}  {'render_mode':>12}  "
+        f"{'repeat':>7}  {'mean_fps':>9}  {'std_fps':>8}  "
+        f"{'min_fps':>8}  {'max_fps':>8}"
+    )
+    print("=" * len(header))
+    print("RENDER-MODE FPS BENCHMARK")
+    print("=" * len(header))
+    print(header)
+    print("-" * len(header))
+
+    for env_id in args.envs:
+        for mode_cfg in RENDER_MODES:
+            result = bench_render_mode(
+                env_id,
+                mode_cfg["render_mode"],
+                mode_cfg["offscreen"],
+                args.steps,
+                args.repeat,
+            )
+            results.append(result)
+            print(
+                f"{result['env']:>25}  {mode_cfg['label']:>12}  "
+                f"{result['n_repeat']:>7}  {result['mean_fps']:>9.2f}  "
+                f"{result['std_fps']:>8.2f}  {result['min_fps']:>8.2f}  "
+                f"{result['max_fps']:>8.2f}"
+            )
+            time.sleep(10)
+        print()
+
+    output = {
+        "meta": {
+            "seed": SEED,
+            "steps": args.steps,
+            "n_repeat": args.repeat,
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "numpy": np.__version__,
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        },
+        "results": results,
+    }
+
+    os.makedirs(os.path.dirname(result_file), exist_ok=True)
+    with open(result_file, "w", encoding="utf-8") as f:
+        json.dump(output, f, indent=2)
+    print(f"Results saved to {result_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate/compare_interp1d.py
+++ b/scripts/validate/compare_interp1d.py
@@ -1,0 +1,107 @@
+"""Benchmark: numpy_interp1d vs scipy.interpolate.interp1d(fill_value="extrapolate")."""
+
+import timeit
+
+import numpy as np
+from scipy import interpolate
+
+from highway_env.road.spline import numpy_interp1d
+
+
+DATA_SIZES = [2, 10, 100, 1_000, 10_000]
+QUERY_SIZES = [1, 10, 100, 1_000, 10_000]
+N_REPEAT = 100_000
+BENCHMARK_SEED = 42
+
+
+def _make_data(n: int, rng: np.random.Generator):
+    x = np.sort(rng.uniform(0, 1000, size=n))
+    y = rng.standard_normal(n)
+    return x, y
+
+
+def _make_query(n: int, x: np.ndarray, rng: np.random.Generator):
+    lo, hi = x[0] - 50, x[-1] + 50
+    return rng.uniform(lo, hi, size=n)
+
+
+def bench_construction():
+    """Constructor check: is numpy_interp1d fast enough to construct."""
+    rng = np.random.default_rng(BENCHMARK_SEED)
+    print("=" * 72)
+    print("CONSTRUCTION TIME (build the interpolator)")
+    print(f"{'data pts':>10}  {'scipy (ms)':>12}  {'numpy (ms)':>12}  {'speedup':>8}")
+    print("-" * 72)
+    for n_data in DATA_SIZES:
+        x, y = _make_data(n_data, rng)
+        ns = {
+            "interpolate": interpolate,
+            "numpy_interp1d": numpy_interp1d,
+            "x": x,
+            "y": y,
+        }
+        t_sp = timeit.Timer(
+            "interpolate.interp1d(x, y, fill_value='extrapolate')", globals=ns
+        ).timeit(N_REPEAT)
+        t_np = timeit.Timer("numpy_interp1d(x, y)", globals=ns).timeit(N_REPEAT)
+        ms_sp = t_sp / N_REPEAT * 1000
+        ms_np = t_np / N_REPEAT * 1000
+        print(f"{n_data:>10}  {ms_sp:>12.4f}  {ms_np:>12.4f}  {ms_sp / ms_np:>7.1f}x")
+
+
+def bench_evaluation():
+    """Evaluation check: is numpy_interp1d fast enough in evaluation."""
+    rng = np.random.default_rng(BENCHMARK_SEED)
+    print()
+    print("=" * 72)
+    print("EVALUATION TIME (call the interpolator)")
+    print(
+        f"{'data pts':>10}  {'query pts':>10}  "
+        f"{'scipy (ms)':>12}  {'numpy (ms)':>12}  {'speedup':>8}"
+    )
+    print("-" * 72)
+    for n_data in DATA_SIZES:
+        x, y = _make_data(n_data, rng)
+        f_sp = interpolate.interp1d(x, y, fill_value="extrapolate")
+        f_np = numpy_interp1d(x, y)
+        for n_query in QUERY_SIZES:
+            q = _make_query(n_query, x, rng)
+            ns = {"f_sp": f_sp, "f_np": f_np, "q": q}
+            t_sp = timeit.Timer("f_sp(q)", globals=ns).timeit(N_REPEAT)
+            t_np = timeit.Timer("f_np(q)", globals=ns).timeit(N_REPEAT)
+            ms_sp = t_sp / N_REPEAT * 1000
+            ms_np = t_np / N_REPEAT * 1000
+            print(
+                f"{n_data:>10}  {n_query:>10}  "
+                f"{ms_sp:>12.4f}  {ms_np:>12.4f}  {ms_sp / ms_np:>7.1f}x"
+            )
+
+
+def validate_correctness():
+    """Sanify check: are they equivalent."""
+    rng = np.random.default_rng(BENCHMARK_SEED)
+    print()
+    print("=" * 72)
+    print("CORRECTNESS VALIDATION (assert_allclose scipy vs numpy)")
+    print("-" * 72)
+    for n_data in DATA_SIZES:
+        x, y = _make_data(n_data, rng)
+        f_sp = interpolate.interp1d(x, y, fill_value="extrapolate")
+        f_np = numpy_interp1d(x, y)
+        for n_query in QUERY_SIZES:
+            q = _make_query(n_query, x, rng)
+            res_sp = f_sp(q)
+            res_np = f_np(q)
+            np.testing.assert_allclose(res_np, res_sp, atol=1e-10)
+            max_diff = np.max(np.abs(res_np - res_sp))
+            print(
+                f"  data={n_data:>5}  query={n_query:>5}  "
+                f"max_abs_diff={max_diff:.2e}  PASS"
+            )
+    print("\nAll correctness checks passed.\n")
+
+
+if __name__ == "__main__":
+    validate_correctness()
+    bench_construction()
+    bench_evaluation()

--- a/scripts/validate/compare_neighbour_detection.py
+++ b/scripts/validate/compare_neighbour_detection.py
@@ -5,10 +5,10 @@ Shows how connected-lane neighbour detection differs when the ego vehicle
 is on one lane segment and a neighbour is on an adjacent connected segment.
 
 Run:
-    python scripts/compare_neighbour_detection.py
-    python scripts/compare_neighbour_detection.py --env racetrack
-    python scripts/compare_neighbour_detection.py --env intersection --no-patch
-    python scripts/compare_neighbour_detection.py --validate
+    python scripts/validate/compare_neighbour_detection.py
+    python scripts/validate/compare_neighbour_detection.py --env racetrack
+    python scripts/validate/compare_neighbour_detection.py --env intersection --no-patch
+    python scripts/validate/compare_neighbour_detection.py --validate
 """
 
 import argparse

--- a/tests/road/test_spline.py
+++ b/tests/road/test_spline.py
@@ -1,0 +1,193 @@
+import numpy as np
+import pytest
+from scipy import interpolate
+
+from highway_env.road.spline import LinearSpline2D, numpy_interp1d
+
+
+@pytest.fixture
+def simple_data():
+    """Five-point dataset with non-uniform spacing."""
+    x = np.array([0.0, 1.0, 3.0, 6.0, 10.0])
+    y = np.array([2.0, 3.0, 5.0, -1.0, 7.0])
+    return x, y
+
+
+@pytest.fixture
+def two_point_data():
+    """Minimal single-segment dataset."""
+    x = np.array([1.0, 4.0])
+    y = np.array([10.0, 25.0])
+    return x, y
+
+
+def _scipy_ref(x, y):
+    return interpolate.interp1d(x, y, fill_value="extrapolate")
+
+
+class TestRepresentative:
+    """Representative cases – interior interpolation."""
+
+    def test_exact_knots(self, simple_data):
+        x, y = simple_data
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(x), f_sp(x))
+
+    def test_midpoints(self, simple_data):
+        x, y = simple_data
+        mids = (x[:-1] + x[1:]) / 2
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(mids), f_sp(mids))
+
+    def test_dense_interior(self, simple_data):
+        x, y = simple_data
+        query = np.linspace(x[0], x[-1], 200)
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(query), f_sp(query))
+
+    def test_scalar_input(self, simple_data):
+        x, y = simple_data
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        for q in [0.5, 2.0, 8.0]:
+            assert isinstance(f_np(q), float)
+            np.testing.assert_allclose(f_np(q), float(f_sp(q)))
+
+    def test_single_element_array(self, simple_data):
+        x, y = simple_data
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        q = np.array([5.0])
+        np.testing.assert_allclose(f_np(q), f_sp(q))
+
+
+class TestBorderline:
+    """Borderline cases – at / near boundaries."""
+
+    def test_first_knot(self, simple_data):
+        x, y = simple_data
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(x[0]), f_sp(x[0]))
+
+    def test_last_knot(self, simple_data):
+        x, y = simple_data
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(x[-1]), f_sp(x[-1]))
+
+    def test_epsilon_inside_left(self, simple_data):
+        x, y = simple_data
+        q = x[0] + 1e-12
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(q), f_sp(q), atol=1e-10)
+
+    def test_epsilon_outside_left(self, simple_data):
+        x, y = simple_data
+        q = x[0] - 1e-12
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(q), f_sp(q), atol=1e-10)
+
+    def test_epsilon_inside_right(self, simple_data):
+        x, y = simple_data
+        q = x[-1] - 1e-12
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(q), f_sp(q), atol=1e-10)
+
+    def test_epsilon_outside_right(self, simple_data):
+        x, y = simple_data
+        q = x[-1] + 1e-12
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(q), f_sp(q), atol=1e-10)
+
+
+class TestExtreme:
+    """Extreme cases."""
+
+    def test_large_extrapolation_left(self, simple_data):
+        x, y = simple_data
+        q = x[0] - 1000.0
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(q), f_sp(q))
+
+    def test_large_extrapolation_right(self, simple_data):
+        x, y = simple_data
+        q = x[-1] + 1000.0
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(q), f_sp(q))
+
+    def test_two_point_interpolation(self, two_point_data):
+        x, y = two_point_data
+        query = np.linspace(x[0], x[-1], 50)
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(query), f_sp(query))
+
+    def test_two_point_extrapolation(self, two_point_data):
+        x, y = two_point_data
+        query = np.array([x[0] - 10.0, x[-1] + 10.0])
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(query), f_sp(query))
+
+    def test_large_array(self):
+        rng = np.random.default_rng(42)
+        x = np.sort(rng.uniform(0, 1000, size=5000))
+        y = rng.standard_normal(5000)
+        query = np.linspace(-10, 1010, 2000)
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(query), f_sp(query), atol=1e-10)
+
+    def test_negative_x_values(self):
+        x = np.array([-10.0, -5.0, -1.0, 0.0, 3.0])
+        y = np.array([1.0, 4.0, 2.0, 0.0, 6.0])
+        query = np.array([-15.0, -7.5, -3.0, 1.5, 5.0])
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(query), f_sp(query))
+
+    def test_mixed_extrapolation_array(self, simple_data):
+        """Query array that includes left-extrapolated, interior, and right-extrapolated points."""
+        x, y = simple_data
+        query = np.array([-5.0, 0.0, 2.0, 5.0, 10.0, 20.0])
+        f_np = numpy_interp1d(x, y)
+        f_sp = _scipy_ref(x, y)
+        np.testing.assert_allclose(f_np(query), f_sp(query))
+
+
+class TestLinearSpline2DIntegration:
+    """Integration test – LinearSpline2D still works after the swap."""
+
+    @pytest.fixture
+    def spline(self):
+        points = [(0, 0), (10, 0), (20, 10), (30, 10), (40, 0)]
+        return LinearSpline2D(points)
+
+    def test_call_at_origin(self, spline):
+        x, y = spline(0.0)
+        np.testing.assert_allclose((x, y), (0.0, 0.0), atol=1e-10)
+
+    def test_call_at_length(self, spline):
+        x, y = spline(spline.length)
+        np.testing.assert_allclose((x, y), (40.0, 0.0), atol=1e-10)
+
+    def test_roundtrip_cartesian_frenet(self, spline):
+        original = (15.0, 3.0)
+        lon, lat = spline.cartesian_to_frenet(original)
+        recovered = spline.frenet_to_cartesian(lon, lat)
+        np.testing.assert_allclose(recovered, original, atol=1.0)
+
+    def test_call_midpoint(self, spline):
+        mid = spline.length / 2
+        x, _ = spline(mid)
+        assert 0.0 <= x <= 40.0


### PR DESCRIPTION
# Description

Remove a heavy dependency - `scipy` by implementing a `numpy_interp1d` helper function to replace `scipy.interpolate.interp1d(x, y, fill_value="extrapolate")`.

Performance difference is as follows, tested on an M4 Macbook Air:
```
========================================================================
CORRECTNESS VALIDATION (assert_allclose scipy vs numpy)
------------------------------------------------------------------------
  data=    2  query=    1  max_abs_diff=0.00e+00  PASS
  data=    2  query=   10  max_abs_diff=1.11e-16  PASS
  data=    2  query=  100  max_abs_diff=1.11e-16  PASS
  data=    2  query= 1000  max_abs_diff=2.22e-16  PASS
  data=    2  query=10000  max_abs_diff=2.22e-16  PASS
  data=   10  query=    1  max_abs_diff=0.00e+00  PASS
  data=   10  query=   10  max_abs_diff=3.89e-16  PASS
  data=   10  query=  100  max_abs_diff=4.44e-16  PASS
  data=   10  query= 1000  max_abs_diff=6.66e-16  PASS
  data=   10  query=10000  max_abs_diff=8.88e-16  PASS
  data=  100  query=    1  max_abs_diff=0.00e+00  PASS
  data=  100  query=   10  max_abs_diff=7.77e-16  PASS
  data=  100  query=  100  max_abs_diff=8.88e-16  PASS
  data=  100  query= 1000  max_abs_diff=1.78e-15  PASS
  data=  100  query=10000  max_abs_diff=1.78e-15  PASS
  data= 1000  query=    1  max_abs_diff=0.00e+00  PASS
  data= 1000  query=   10  max_abs_diff=2.84e-14  PASS
  data= 1000  query=  100  max_abs_diff=5.68e-14  PASS
  data= 1000  query= 1000  max_abs_diff=5.68e-14  PASS
  data= 1000  query=10000  max_abs_diff=1.14e-13  PASS
  data=10000  query=    1  max_abs_diff=1.14e-13  PASS
  data=10000  query=   10  max_abs_diff=3.55e-15  PASS
  data=10000  query=  100  max_abs_diff=3.64e-12  PASS
  data=10000  query= 1000  max_abs_diff=3.64e-12  PASS
  data=10000  query=10000  max_abs_diff=3.64e-12  PASS

All correctness checks passed.

========================================================================
CONSTRUCTION TIME (build the interpolator)
  data pts    scipy (ms)    numpy (ms)   speedup
------------------------------------------------------------------------
         2        0.0039        0.0001     58.8x
        10        0.0040        0.0001     60.3x
       100        0.0057        0.0001     71.7x
      1000        0.0076        0.0001    114.3x
     10000        0.0348        0.0001    528.8x

========================================================================
EVALUATION TIME (call the interpolator)
  data pts   query pts    scipy (ms)    numpy (ms)   speedup
------------------------------------------------------------------------
         2           1        0.0060        0.0042      1.4x
         2          10        0.0062        0.0043      1.4x
         2         100        0.0070        0.0062      1.1x
         2        1000        0.0133        0.0113      1.2x
         2       10000        0.0756        0.0633      1.2x
        10           1        0.0060        0.0027      2.2x
        10          10        0.0061        0.0043      1.4x
        10         100        0.0069        0.0065      1.1x
        10        1000        0.0149        0.0131      1.1x
        10       10000        0.0914        0.0832      1.1x
       100           1        0.0059        0.0027      2.2x
       100          10        0.0062        0.0044      1.4x
       100         100        0.0072        0.0078      0.9x
       100        1000        0.0180        0.0253      0.7x
       100       10000        0.1395        0.2019      0.7x
      1000           1        0.0060        0.0027      2.2x
      1000          10        0.0062        0.0061      1.0x
      1000         100        0.0076        0.0089      0.8x
      1000        1000        0.0215        0.0372      0.6x
      1000       10000        0.3242        0.3326      1.0x
     10000           1        0.0061        0.0043      1.4x
     10000          10        0.0063        0.0047      1.3x
     10000         100        0.0082        0.0102      0.8x
     10000        1000        0.0255        0.0503      0.5x
     10000       10000        0.4452        0.4494      1.0x
```

The performance difference is acceptable (0.5x ~ 2.2x), `scripts/regression_test/bench_render_fps.py` also validated this is a performance-neutral change.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Performance improvement (non-breaking change that improves speed, memory, or resource usage)
- [x] Compatibility fix or other chore tasks

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If my code may add latency, I've tested locally and provided details in description above

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
