### PR TITLE
Add a generic version of the merge environment

### DIFF
--- a/highway_env/__init__.py
+++ b/highway_env/__init__.py
@@ -100,6 +100,14 @@ def _register_highway_envs():
         id="merge-v1",
         entry_point="highway_env.envs.merge_env:ConnectedLaneMergeEnv",
     )
+    register(
+        id="merge-generic-v0",
+        entry_point="highway_env.envs.merge_env:MergeGenericEnv",
+    )
+    register(
+        id="merge-generic-v1",
+        entry_point="highway_env.envs.merge_env:ConnectedLaneMergeGenericEnv",
+    )
 
     # parking_env.py
     register(

--- a/highway_env/envs/merge_env.py
+++ b/highway_env/envs/merge_env.py
@@ -185,3 +185,186 @@ class MergeEnv(AbstractEnv):
 
 class ConnectedLaneMergeEnv(ConnectedLaneNeighboursMixin, MergeEnv):
     pass
+
+
+class MergeGenericEnv(MergeEnv):
+    """
+    A generic version of the merge environment.
+    Additionally supports changing:
+    - the number of lanes
+    - the number of vehicles
+    - the size of each section of the merging road
+
+    Visual representation of each configurable merging road segment:
+    ======================================
+    --------------------------------------
+    ======================================
+               /  __________/  (after)
+              /  / (parallel)
+             /  /
+    ________/  /(converge)
+    __________/
+     (before)
+    """
+
+    @classmethod
+    def default_config(cls) -> dict:
+        cfg = super().default_config()
+        cfg.update(
+            {
+                "lanes_count": 2,
+                "vehicles_count": 10,
+                # Parameters that define the size of each component of the merging road:
+                # Section before the merge segment (must be >= 60)
+                "before_merge_length": 150,
+                # Section converging closer to the highway
+                "converge_merge_length": 80,
+                # Section where the vehicle can merge into the highway
+                "parallel_merge_length": 80,
+                # Section after the merge segment (must be >= 100)
+                "after_merge_length": 300,
+            }
+        )
+        return cfg
+
+    def _make_road(self) -> None:
+        net = RoadNetwork()
+        lanes = self.config["lanes_count"]
+        pre_merge = self.config["before_merge_length"]
+        converge = self.config["converge_merge_length"]
+        parallel = self.config["parallel_merge_length"]
+        after = self.config["after_merge_length"]
+
+        net = RoadNetwork.straight_road_network(
+            lanes,
+            start=0,
+            length=pre_merge + converge,
+            nodes_str=("a", "b"),
+            speed_limit=30,
+            net=net,
+        )
+        net = RoadNetwork.straight_road_network(
+            lanes,
+            start=pre_merge + converge,
+            length=parallel,
+            nodes_str=("b", "c"),
+            speed_limit=30,
+            net=net,
+        )
+        net = RoadNetwork.straight_road_network(
+            lanes,
+            start=pre_merge + converge + parallel,
+            length=after,
+            nodes_str=("c", "d"),
+            speed_limit=30,
+            net=net,
+        )
+
+        amplitude = 3.25
+        y_parallel = lanes * StraightLane.DEFAULT_WIDTH
+        y_approach = y_parallel + 2 * amplitude
+
+        ljk = StraightLane(
+            [0, y_approach],
+            [pre_merge, y_approach],
+            line_types=[LineType.CONTINUOUS_LINE, LineType.CONTINUOUS_LINE],
+            forbidden=True,
+            speed_limit=30,
+        )
+        lkb = SineLane(
+            [pre_merge, y_parallel + amplitude],
+            [pre_merge + converge, y_parallel + amplitude],
+            amplitude,
+            2 * np.pi / (2 * converge),
+            np.pi / 2,
+            line_types=[LineType.CONTINUOUS_LINE, LineType.CONTINUOUS_LINE],
+            forbidden=True,
+            speed_limit=30,
+        )
+        lbc = StraightLane(
+            [pre_merge + converge, y_parallel],
+            [pre_merge + converge + parallel, y_parallel],
+            line_types=[LineType.STRIPED, LineType.CONTINUOUS_LINE],
+            forbidden=True,
+            speed_limit=30,
+        )
+
+        net.add_lane("j", "k", ljk)
+        net.add_lane("k", "b", lkb)
+        net.add_lane("b", "c", lbc)
+
+        road = Road(
+            network=net,
+            np_random=self.np_random,
+            record_history=self.config.get("show_trajectories", False),
+        )
+        road.objects.append(Obstacle(road, lbc.position(parallel, 0)))
+        self.road = road
+
+    def _make_vehicles(self) -> None:
+        road = self.road
+        lanes = self.config["lanes_count"]
+
+        pre_merge = self.config["before_merge_length"]
+        converge = self.config["converge_merge_length"]
+        parallel = self.config["parallel_merge_length"]
+
+        ego_lane = road.network.get_lane(("a", "b", lanes - 1))
+        ego_longitudinal = 30.0
+        ego_vehicle = self.action_type.vehicle_class(
+            road,
+            ego_lane.position(ego_longitudinal, 0.0),
+            speed=30.0,
+        )
+        road.vehicles.append(ego_vehicle)
+        self.vehicle = ego_vehicle
+
+        other_vehicles_type = utils.class_from_path(self.config["other_vehicles_type"])
+        vehicles_count = self.config["vehicles_count"]
+        max_pos = pre_merge + converge + parallel
+
+        spawned_positions = {i: [] for i in range(lanes)}
+        spawned_positions[lanes - 1].append(ego_longitudinal)
+        safe_distance = 15.0  # safe distance to spawn vehicles from each other
+        tries = 10  # number of times it tries to spawn a vehicle
+        for _ in range(vehicles_count):
+            for _ in range(tries):
+                random_lane_index = self.np_random.integers(lanes)
+                longitudinal = self.np_random.uniform(0, max_pos)
+
+                if all(
+                    abs(longitudinal - p) > safe_distance
+                    for p in spawned_positions[random_lane_index]
+                ):
+                    lane = road.network.get_lane(("a", "b", random_lane_index))
+                    pos = lane.position(longitudinal, 0.0)
+                    spd = 30.0 + self.np_random.uniform(-2.0, 2.0)
+
+                    road.vehicles.append(other_vehicles_type(road, pos, speed=spd))
+                    spawned_positions[random_lane_index].append(longitudinal)
+                    break
+
+        merge_lane = road.network.get_lane(("j", "k", 0))
+        merging_v = other_vehicles_type(
+            road, merge_lane.position(ego_longitudinal + 30, 0.0), speed=20.0
+        )
+        merging_v.target_speed = 30.0
+        road.vehicles.append(merging_v)
+
+    def _is_terminated(self) -> bool:
+        """The episode is over when a collision occurs or when the access ramp has been passed."""
+        end_position = (
+            self.config["before_merge_length"]
+            + self.config["converge_merge_length"]
+            + self.config["parallel_merge_length"]
+            + self.config["after_merge_length"]
+            - 100
+        )
+        return self.vehicle.crashed or self.vehicle.position[0] > end_position
+
+    def _is_truncated(self) -> bool:
+        return False
+
+
+class ConnectedLaneMergeGenericEnv(ConnectedLaneNeighboursMixin, MergeGenericEnv):
+    pass

--- a/highway_env/envs/merge_env.py
+++ b/highway_env/envs/merge_env.py
@@ -219,16 +219,16 @@ class MergeGenericEnv(MergeEnv):
         cfg.update(
             {
                 "lanes_count": 2,
-                "vehicles_count": 10,
+                "vehicles_count": 3,
                 # Parameters that define the size of each component of the merging road:
-                # Section before the merge segment (must be >= 60)
+                # Section before the merge segment (recommended to be >= 60)
                 "before_merge_length": 150,
                 # Section converging closer to the highway
                 "converge_merge_length": 80,
                 # Section where the vehicle can merge into the highway
                 "parallel_merge_length": 80,
-                # Section after the merge segment (must be >= 100)
-                "after_merge_length": 300,
+                # Section after the merge segment (must be >= 90)
+                "after_merge_length": 150,
             }
         )
         return cfg
@@ -240,7 +240,7 @@ class MergeGenericEnv(MergeEnv):
         converge = self.config["converge_merge_length"]
         parallel = self.config["parallel_merge_length"]
         after = self.config["after_merge_length"]
-        self.end_position = pre_merge + converge + parallel + after - 100
+        self.end_position = pre_merge + converge + parallel + after - 90
 
         net = RoadNetwork.straight_road_network(
             lanes,
@@ -304,6 +304,9 @@ class MergeGenericEnv(MergeEnv):
             network=net,
             np_random=self.np_random,
             record_history=self.config.get("show_trajectories", False),
+            neighbour_vehicles_connected_lanes=self.config[
+                "neighbour_vehicles_connected_lanes"
+            ],
         )
         road.objects.append(Obstacle(road, lbc.position(parallel, 0)))
         self.road = road

--- a/highway_env/envs/merge_env.py
+++ b/highway_env/envs/merge_env.py
@@ -240,6 +240,10 @@ class MergeGenericEnv(MergeEnv):
         converge = self.config["converge_merge_length"]
         parallel = self.config["parallel_merge_length"]
         after = self.config["after_merge_length"]
+        assert all(
+            road_segment > 0 for road_segment in [pre_merge, converge, parallel]
+        ), "All road segments must have positive length"
+        assert after >= 90, "The after merge road segment must have length >= 90"
         self.end_position = pre_merge + converge + parallel + after - 90
 
         net = RoadNetwork.straight_road_network(

--- a/highway_env/envs/merge_env.py
+++ b/highway_env/envs/merge_env.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from itertools import repeat
+
 import numpy as np
 
 from highway_env import utils
@@ -207,6 +209,10 @@ class MergeGenericEnv(MergeEnv):
      (before)
     """
 
+    def __init__(self, config: dict = None, render_mode: str | None = None) -> None:
+        self.end_position = 0
+        super().__init__(config=config, render_mode=render_mode)
+
     @classmethod
     def default_config(cls) -> dict:
         cfg = super().default_config()
@@ -234,6 +240,7 @@ class MergeGenericEnv(MergeEnv):
         converge = self.config["converge_merge_length"]
         parallel = self.config["parallel_merge_length"]
         after = self.config["after_merge_length"]
+        self.end_position = pre_merge + converge + parallel + after - 100
 
         net = RoadNetwork.straight_road_network(
             lanes,
@@ -327,8 +334,8 @@ class MergeGenericEnv(MergeEnv):
         spawned_positions[lanes - 1].append(ego_longitudinal)
         safe_distance = 15.0  # safe distance to spawn vehicles from each other
         tries = 10  # number of times it tries to spawn a vehicle
-        for _ in range(vehicles_count):
-            for _ in range(tries):
+        for _ in repeat(None, vehicles_count):
+            for _ in repeat(None, tries):
                 random_lane_index = self.np_random.integers(lanes)
                 longitudinal = self.np_random.uniform(0, max_pos)
 
@@ -353,14 +360,7 @@ class MergeGenericEnv(MergeEnv):
 
     def _is_terminated(self) -> bool:
         """The episode is over when a collision occurs or when the access ramp has been passed."""
-        end_position = (
-            self.config["before_merge_length"]
-            + self.config["converge_merge_length"]
-            + self.config["parallel_merge_length"]
-            + self.config["after_merge_length"]
-            - 100
-        )
-        return self.vehicle.crashed or self.vehicle.position[0] > end_position
+        return self.vehicle.crashed or self.vehicle.position[0] > self.end_position
 
     def _is_truncated(self) -> bool:
         return False

--- a/tests/envs/test_gym.py
+++ b/tests/envs/test_gym.py
@@ -28,6 +28,7 @@ CHECK_ENV_IGNORE_WARNINGS = [
         # "For Box action spaces, we recommend using a symmetric and normalized space (range=[-1, 1] or [0, 1]). See https://stable-baselines3.readthedocs.io/en/master/guide/rl_tips.html for more information.",
         "The environment exit-v0 is out of date. You should consider upgrading to version `v1`.",
         "The environment merge-v0 is out of date. You should consider upgrading to version `v1`.",
+        "The environment merge-generic-v0 is out of date. You should consider upgrading to version `v1`.",
         "The environment racetrack-v0 is out of date. You should consider upgrading to version `v1`.",
         "The environment racetrack-large-v0 is out of date. You should consider upgrading to version `v1`.",
         "The environment racetrack-oval-v0 is out of date. You should consider upgrading to version `v1`.",
@@ -105,6 +106,7 @@ def test_env_reset_options(env_spec: str = "highway-v0"):
     [
         ("exit-v0", "exit-v1"),
         ("merge-v0", "merge-v1"),
+        ("merge-generic-v0", "merge-generic-v1"),
         ("roundabout-v0", "roundabout-v1"),
         ("roundabout-generic-v0", "roundabout-generic-v1"),
         ("racetrack-v0", "racetrack-v1"),


### PR DESCRIPTION
# Description

This PR adds a new version of the merge environment, a class called `MergeGenericEnv`, registered as `merge-generic-v0`, with configurable parameters:
- Number of lanes
- Number of spawned vehicles
- The size of each section of the merging road

I also made sure to include a `v1` version for the connected lane fix.

## Context
I wanted to have some configurable options for several HighwayEnv environments, and ended up making a more generic version of the merge environment. I also made a generic version for the roundabout with the same idea, which was already included some time ago in #669.

I'm open to make requested changes to the environment.

## Type of change

- [X] New environment or environment variant

### Screenshots
Here are screenshots of two different configurations from the environment. Both use the default road size parameters:

| `config={"lanes_count": 2, "vehicles_count": 10}` (default) | `config={"lanes_count": 3, "vehicles_count": 20}`|
|:-:|:-:|
| <img width="601" height="184" alt="Screenshot of default configuration for merge-generic-v0" src="https://github.com/user-attachments/assets/22285ec8-207a-4d5d-b1ce-eb83c5d15d48" />| <img width="594" height="187" alt="Screenshot for merge-generic-v0 configuration with more lanes and vehicles" src="https://github.com/user-attachments/assets/4622adda-ecc3-40b0-aae9-3ccde79c6409" />| 

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] If my code may add latency, I've tested locally and provided details in description above
