### PR TITLE
fix!: ensure compliance with Gymnasium's definition of render_mode

### DIFF
--- a/.github/workflows/build-docs-dev.yml
+++ b/.github/workflows/build-docs-dev.yml
@@ -9,8 +9,6 @@ on:
         - '.github/workflows/build-docs*.yml'
 permissions:
   contents: write
-env:
-  OFFSCREEN_RENDERING: 1
 jobs:
   docs:
     name: Generate Website

--- a/.github/workflows/build-docs-version.yml
+++ b/.github/workflows/build-docs-version.yml
@@ -5,8 +5,6 @@ on:
       - 'v*.*'
 permissions:
   contents: write
-env:
-  OFFSCREEN_RENDERING: 1
 jobs:
   docs:
     name: Generate Website for new version

--- a/.github/workflows/manual-build-docs-version.yml
+++ b/.github/workflows/manual-build-docs-version.yml
@@ -14,8 +14,6 @@ on:
 
 permissions:
   contents: write
-env:
-  OFFSCREEN_RENDERING: 1
 jobs:
   docs:
     name: Generate Website for new version

--- a/docs/environments/highway.md
+++ b/docs/environments/highway.md
@@ -53,7 +53,7 @@ env = gym.make("highway-v0")
     "scaling": 5.5,
     "show_trajectories": False,
     "render_agent": True,
-    "offscreen_rendering": False
+    "offscreen_rendering": None
 }
 ```
 

--- a/docs/environments/merge.md
+++ b/docs/environments/merge.md
@@ -56,7 +56,7 @@ See {ref}`road-neighbour-vehicles` for details.
     "scaling": 5.5,
     "show_trajectories": False,
     "render_agent": True,
-    "offscreen_rendering": False
+    "offscreen_rendering": None
 }
 ```
 

--- a/docs/environments/parking.md
+++ b/docs/environments/parking.md
@@ -57,7 +57,7 @@ env = gym.make("parking-v0")
     "scaling": 7,
     "show_trajectories": False,
     "render_agent": True,
-    "offscreen_rendering": False
+    "offscreen_rendering": None
 }
 ```
 

--- a/docs/environments/racetrack.md
+++ b/docs/environments/racetrack.md
@@ -69,7 +69,7 @@ See {ref}`road-neighbour-vehicles` for details.
     "centering_position": [0.5, 0.5],
     "show_trajectories": False,
     "render_agent": True,
-    "offscreen_rendering": False
+    "offscreen_rendering": None
 }
 ```
 

--- a/docs/environments/roundabout.md
+++ b/docs/environments/roundabout.md
@@ -65,7 +65,7 @@ See {ref}`road-neighbour-vehicles` for details.
     "scaling": 5.5,
     "show_trajectories": False,
     "render_agent": True,
-    "offscreen_rendering": False
+    "offscreen_rendering": None
 }
 ```
 

--- a/docs/graphics/index.md
+++ b/docs/graphics/index.md
@@ -6,11 +6,65 @@
 
 Environment rendering is done with [pygame community edition](https://pyga.me), a maintained fork of the original [pygame](https://www.pygame.org/news) library.
 
+## Render modes
+
+```{warning}
+Since v1.12, `offscreen_rendering` defaults to `None` and is derived from `render_mode`.
+Previously, users would manually set `offscreen_rendering=True` for headless rendering.
+The associated `OFFSCREEN_RENDERING` environment variable is also deprecated & ignored.
+```
+
+HighwayEnv follows [Gymnasium's convention](https://gymnasium.farama.org/main/api/env/#gymnasium.Env.render) for `render_mode`:
+
+```python
+import gymnasium as gym
+
+# No rendering (fastest, for training with no visual information)
+env = gym.make("highway-v0")
+
+# Pixel array (for recording or pixel-based observations)
+env = gym.make("highway-v0", render_mode="rgb_array")
+
+# Visual window (for human viewing, render as fast as possible)
+env = gym.make("highway-v0", render_mode="human")
+
+# Visual window (for human viewing, at pre-set framerate)
+env = gym.make("highway-v0", render_mode="human", config={"real_time_rendering": True})
+```
+
+| `render_mode`   | Default window | `render()` returns    | Auto-renders on step/reset |
+|-----------------|----------------|-----------------------|----------------------------|
+| `None`          | No             | `None` (warns)        | No                         |
+| `"rgb_array"`   | No             | `np.ndarray (H,W,3)`  | No                         |
+| `"human"`       | Yes            | `None`                | Yes                        |
+
+## Rendering configuration
+
+The following config keys control rendering behavior. When `offscreen_rendering` is left as `None` (default), it would be derived from `render_mode`:
+
+| Config key             | Default                                 | Window |
+|------------------------|-----------------------------------------|--------|
+| `offscreen_rendering`  | `False` for `"human"`, `True` otherwise | No when `True`, Yes when `False` |
+| `real_time_rendering`  | `False`                                 | N/A    |
+
+- **`offscreen_rendering`**: When `True`, no pygame display window is created. Drawing is done to an off-screen surface only. Useful for headless servers or when you only need pixel arrays.
+- **`real_time_rendering`**: When `True`, the display is synced to render at `simulation_frequency` frames per second so that simulations play at real-time speed. Only has an effect when a window is shown (i.e. `render_mode="human"` or `offscreen_rendering=False`).
+
+These can be explicitly overridden in config when needed:
+
+```python
+# rgb_array mode but also show a window (e.g. for debugging)
+env = gym.make("highway-v0", render_mode="rgb_array", config={"offscreen_rendering": False})
+```
+
+## Window configuration
+
 A window is created at the first call of `env.render()`. Its dimensions can be configured:
 
 ```python
 env = gym.make(
     "roundabout-v0",
+    render_mode="human",
     config={
         "screen_width": 640,
         "screen_height": 480

--- a/highway_env/envs/common/abstract.py
+++ b/highway_env/envs/common/abstract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import os
+import warnings
 from typing import TypeVar
 
 import gymnasium as gym
@@ -58,6 +59,13 @@ class AbstractEnv(gym.Env):
     def __init__(self, config: dict = None, render_mode: str | None = None) -> None:
         super().__init__()
 
+        # Rendering
+        assert render_mode is None or render_mode in self.metadata["render_modes"]
+        self.render_mode = render_mode
+        self.viewer = None
+        self._record_video_wrapper = None
+        self.enable_auto_render = False
+
         # Configuration
         self.config = self.default_config()
         self.configure(config)
@@ -77,13 +85,6 @@ class AbstractEnv(gym.Env):
         self.time = 0  # Simulation time
         self.steps = 0  # Actions performed
         self.done = False
-
-        # Rendering
-        self.viewer = None
-        self._record_video_wrapper = None
-        assert render_mode is None or render_mode in self.metadata["render_modes"]
-        self.render_mode = render_mode
-        self.enable_auto_render = False
 
         self.reset()
 
@@ -117,7 +118,7 @@ class AbstractEnv(gym.Env):
             "scaling": 5.5,
             "show_trajectories": False,
             "render_agent": True,
-            "offscreen_rendering": os.environ.get("OFFSCREEN_RENDERING", "0") == "1",
+            "offscreen_rendering": None,
             "manual_control": False,
             "real_time_rendering": False,
             "neighbour_vehicles_connected_lanes": False,
@@ -126,6 +127,21 @@ class AbstractEnv(gym.Env):
     def configure(self, config: dict) -> None:
         if config:
             self.config.update(config)
+
+        if "OFFSCREEN_RENDERING" in os.environ:
+            suggestion = (
+                "rgb_array" if os.getenv("OFFSCREEN_RENDERING") == "1" else "human"
+            )
+            warnings.warn(
+                f"\033[31mhighway_env.{self.__class__.__name__}:\033[0m "
+                "The OFFSCREEN_RENDERING environment variable is deprecated "
+                f'and ignored. Use render_mode="{suggestion}" instead.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        if self.config["offscreen_rendering"] is None:
+            self.config["offscreen_rendering"] = self.render_mode != "human"
 
     def update_metadata(self, video_real_time_ratio=2):
         frames_freq = (
@@ -313,7 +329,7 @@ class AbstractEnv(gym.Env):
                 "You can specify the render_mode at initialization, "
                 f'e.g. gym.make("{self.spec.id}", render_mode="rgb_array")'
             )
-            return
+            return None
         if self.viewer is None:
             self.viewer = EnvViewer(self)
 
@@ -324,8 +340,8 @@ class AbstractEnv(gym.Env):
         if not self.viewer.offscreen:
             self.viewer.handle_events()
         if self.render_mode == "rgb_array":
-            image = self.viewer.get_image()
-            return image
+            return self.viewer.get_image()
+        return None
 
     def close(self) -> None:
         """

--- a/tests/graphics/test_gym_render_mode.py
+++ b/tests/graphics/test_gym_render_mode.py
@@ -1,0 +1,116 @@
+import os
+import warnings
+
+import gymnasium as gym
+import numpy as np
+import pytest
+
+import highway_env
+
+
+gym.register_envs(highway_env)
+
+ENV_ID = "highway-v0"
+
+skip_headless = pytest.mark.skipif(
+    os.environ.get("SDL_VIDEODRIVER") == "dummy",
+    reason="Requires a display (skipped in headless CI)",
+)
+
+
+class TestRenderModeDefaults:
+    def test_none_derives_offscreen(self):
+        env = gym.make(ENV_ID)
+        assert env.unwrapped.config["offscreen_rendering"] is True
+        assert env.unwrapped.config["real_time_rendering"] is False
+        env.close()
+
+    def test_rgb_array_derives_offscreen(self):
+        env = gym.make(ENV_ID, render_mode="rgb_array")
+        assert env.unwrapped.config["offscreen_rendering"] is True
+        assert env.unwrapped.config["real_time_rendering"] is False
+        env.close()
+
+    @skip_headless
+    def test_human_derives_onscreen(self):
+        env = gym.make(ENV_ID, render_mode="human")
+        assert env.unwrapped.config["offscreen_rendering"] is False
+        assert env.unwrapped.config["real_time_rendering"] is False
+        env.close()
+
+    def test_explicit_override_respected(self):
+        env = gym.make(
+            ENV_ID, render_mode="rgb_array", config={"offscreen_rendering": False}
+        )
+        assert env.unwrapped.config["offscreen_rendering"] is False
+        env.close()
+
+
+class TestRenderReturn:
+    def test_none_returns_none(self):
+        env = gym.make(ENV_ID)
+        env.reset()
+        result = env.render()
+        assert result is None
+        env.close()
+
+    def test_rgb_array_returns_ndarray(self):
+        env = gym.make(ENV_ID, render_mode="rgb_array")
+        env.reset()
+        img = env.render()
+        assert isinstance(img, np.ndarray)
+        assert img.shape == (
+            env.unwrapped.config["screen_height"],
+            env.unwrapped.config["screen_width"],
+            3,
+        )
+        env.close()
+
+    @skip_headless
+    def test_human_returns_none(self):
+        env = gym.make(ENV_ID, render_mode="human")
+        env.reset()
+        result = env.render()
+        assert result is None
+        env.close()
+
+    @skip_headless
+    def test_rgb_array_with_window_still_returns_ndarray(self):
+        env = gym.make(
+            ENV_ID, render_mode="rgb_array", config={"offscreen_rendering": False}
+        )
+        env.reset()
+        img = env.render()
+        assert isinstance(img, np.ndarray)
+        assert img.shape[2] == 3
+        env.close()
+
+    def test_human_with_offscreen_returns_none(self):
+        env = gym.make(
+            ENV_ID, render_mode="human", config={"offscreen_rendering": True}
+        )
+        env.reset()
+        result = env.render()
+        assert result is None
+        env.close()
+
+
+class TestDeprecation:
+    def test_offscreen_env_var_emits_warning(self):
+        original_val = os.getenv("OFFSCREEN_RENDERING")
+        os.environ["OFFSCREEN_RENDERING"] = "1"
+        try:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                env = gym.make(ENV_ID, render_mode="rgb_array")
+                env.close()
+            assert any(
+                issubclass(x.category, DeprecationWarning)
+                and "OFFSCREEN_RENDERING" in str(x.message)
+                for x in w
+            )
+        finally:
+            if original_val is None:
+                del os.environ["OFFSCREEN_RENDERING"]
+            else:
+                os.environ["OFFSCREEN_RENDERING"] = original_val

--- a/tests/graphics/test_render.py
+++ b/tests/graphics/test_render.py
@@ -11,7 +11,6 @@ gym.register_envs(highway_env)
 @pytest.mark.parametrize("env_spec", ["highway-v0", "merge-v0"])
 def test_render(env_spec):
     env = gym.make(env_spec, render_mode="rgb_array").unwrapped
-    env.config.update({"offscreen_rendering": True})
     env.reset()
     img = env.render()
     env.close()


### PR DESCRIPTION
> # This is a borderline breaking change

# Description

As discussed in #688, currently HighwayEnv did not implement render mode [according to Gymnasium](https://gymnasium.farama.org/main/api/env/#gymnasium.Env.render); instead, whether the environments are actually rendered is set with the `offscreen_rendering` config key, making `render_mode` kinda pointless.

This PR introduced correct behaviour to treating different values of `render_mode`, while still keeping old behaviour when possible:

- `render_mode="human"` -> render to window, render() returns None
- `render_mode="rgb_array"` -> headless render, render() returns array
- kept `offscreen_rendering` in config as override
- the `OFFSCREEN_RENDERING` environment variable is removed because [explicit is better than implicit](https://peps.python.org/pep-0020/#the-zen-of-python).

Additionally, documentation is also updated to explain:
1. What `offscreen_rendering` and `real_time_rendering` do?
2. What does each `render_mode` mean?
3. How to combine `render_mode` with `offscreen_rendering` and `real_time_rendering`?
4. Warning about old and new behaviour.

Fixes #688 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Compatibility fix or other chore tasks
- [x] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If my code may add latency, I've tested locally and provided details in description above

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
