### PR TITLE
fix: prevent silent uint8 overflow of OccupancyGrid observation shape

### DIFF
--- a/highway_env/envs/common/observation.py
+++ b/highway_env/envs/common/observation.py
@@ -317,7 +317,7 @@ class OccupancyGridObservation(ObservationType):
         )
         grid_shape = np.asarray(
             np.floor((self.grid_size[:, 1] - self.grid_size[:, 0]) / self.grid_step),
-            dtype=int,
+            dtype=np.intp,
         )
         self.grid = np.zeros((len(self.features), *grid_shape))
         self.features_range = features_range

--- a/highway_env/envs/common/observation.py
+++ b/highway_env/envs/common/observation.py
@@ -317,7 +317,7 @@ class OccupancyGridObservation(ObservationType):
         )
         grid_shape = np.asarray(
             np.floor((self.grid_size[:, 1] - self.grid_size[:, 0]) / self.grid_step),
-            dtype=np.uint8,
+            dtype=int,
         )
         self.grid = np.zeros((len(self.features), *grid_shape))
         self.features_range = features_range

--- a/tests/envs/test_observations.py
+++ b/tests/envs/test_observations.py
@@ -24,5 +24,23 @@ def test_observation_type(observation_config):
     env.close()
 
 
+def test_occupancy_grid_shape_no_uint8_overflow():
+    # Regression: grid_shape was cast to uint8 and silently wrapped
+    # (mod 256) for grids with more than 255 cells along an axis.
+    config = {
+        "observation": {
+            "type": "OccupancyGrid",
+            "grid_size": [[-300, 300], [-10, 10]],
+            "grid_step": [2, 2],
+        }
+    }
+    env = gym.make("highway-v0", config=config)
+    obs, _ = env.reset()
+    # 4 default features (presence, vx, vy, on_road) x 300 x 10 cells
+    assert env.observation_space.shape == (4, 300, 10)
+    assert obs.shape == (4, 300, 10)
+    env.close()
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## What

`OccupancyGridObservation.__init__` computes the grid shape (number of cells per axis) and casts it to `np.uint8`:

```python
grid_shape = np.asarray(
    np.floor((self.grid_size[:, 1] - self.grid_size[:, 0]) / self.grid_step),
    dtype=np.uint8,
)
```

A cell count is an array dimension, not pixel data. This changes the dtype to `int`.

## Why

Casting cell counts to `uint8` silently wraps any axis with more than 255 cells modulo 256. The resulting `self.grid` — and therefore the `Box` observation space and every returned observation — is the wrong size, and `pos_to_index`'s bounds check `0 <= cell < self.grid.shape[...]` then drops vehicles that fall in legitimate cells. There is no error; the observation is just quietly corrupted.

The default config (11x11 cells) stays under 255, so the bug has remained latent. Any user with a fine-grained or large occupancy grid hits it. For example, `grid_size=[[-300, 300], [-10, 10]]` with `grid_step=[2, 2]` should produce 300 cells along the x-axis, but `300 % 256 = 44`, so the observation silently becomes 44 cells wide.

## Testing

Added `test_occupancy_grid_shape_no_uint8_overflow`, which builds a >255-cell grid and asserts both the observation space and a reset observation have the expected `(4, 300, 10)` shape. It fails on `main` (`(4, 44, 10)`) and passes with this change.

```
$ pytest tests/envs/test_observations.py -q
..                                                                       [100%]
2 passed in 0.63s
```

No default-config behavior changes: the default OccupancyGrid is 11x11 cells, well under 255, so `int` and `uint8` agree there.
