### PR TITLE
fix: restore 100-step parking-v0 episodes (duration 100 -> 20)

### DIFF
--- a/docs/environments/parking.md
+++ b/docs/environments/parking.md
@@ -47,7 +47,7 @@ env = gym.make("parking-v0")
     "steering_range": np.deg2rad(45),
     "simulation_frequency": 15,
     "policy_frequency": 5,
-    "duration": 100,
+    "duration": 20,
     "controlled_vehicles": 1,
     "vehicles_count": 0,
     "add_walls": True,

--- a/highway_env/envs/parking_env.py
+++ b/highway_env/envs/parking_env.py
@@ -100,7 +100,7 @@ class ParkingEnv(AbstractEnv, GoalEnv):
                 "steering_range": np.deg2rad(45),
                 "simulation_frequency": 15,
                 "policy_frequency": 5,
-                "duration": 100,
+                "duration": 20,
                 "screen_width": 600,
                 "screen_height": 300,
                 "centering_position": [0.5, 0.5],

--- a/tests/envs/test_gym.py
+++ b/tests/envs/test_gym.py
@@ -101,6 +101,34 @@ def test_env_reset_options(env_spec: str = "highway-v0"):
     assert env.config["duration"] == update_duration
 
 
+def test_parking_default_episode_length():
+    # Regression test for https://github.com/Farama-Foundation/HighwayEnv/issues/674
+    # `duration` is expressed in simulated seconds, so an episode lasts
+    # ~`duration * policy_frequency` policy steps. The default parking-v0
+    # config must yield ~100-step episodes (not the previous 500) to stay
+    # consistent with the canonical RL-Zoo / SB3 hyperparameters
+    # (learning_starts=100, HER max_episode_length=100).
+    env = gym.make("parking-v0").unwrapped
+    config = env.config
+    assert config["duration"] == 20
+    expected_steps = config["duration"] * config["policy_frequency"]
+    assert expected_steps == 100
+
+    env.reset(seed=0)
+    steps = 0
+    terminated = truncated = False
+    while not (terminated or truncated):
+        # A zero action keeps the vehicle at rest, so the episode ends by
+        # truncation at the time horizon rather than by crashing or success.
+        _, _, terminated, truncated, _ = env.step(np.zeros(env.action_space.shape))
+        steps += 1
+    assert truncated and not terminated
+    # The horizon is `duration * policy_frequency` steps, give or take a single
+    # step from floating-point accumulation of `time += 1 / policy_frequency`.
+    assert abs(steps - expected_steps) <= 1
+    env.close()
+
+
 @pytest.mark.parametrize(
     ("old_env_spec", "new_env_spec"),
     [


### PR DESCRIPTION
# Description

`duration` is expressed in simulated seconds, and an episode is truncated once `self.time >= duration`, where `self.time` advances by `1 / policy_frequency` per policy step. With the default `duration: 100` and `policy_frequency: 5`, `parking-v0` episodes therefore run `100 * 5 = 500` policy steps — not the ~100 that the canonical RL-Zoo / SB3 recipes were tuned for (`learning_starts=100`, HER `max_episode_length=100`). Out of the box, those recipes now fail with `RuntimeError: Unable to sample before the end of the first episode.`

This PR sets the default `duration` to `20` (`20 s × 5 Hz = 100` policy steps), matching the sibling `ParkingEnvActionRepeat` (which already uses `duration: 20`) and the value suggested by @eleurent in the issue thread. The documented default config in `docs/environments/parking.md` is updated to stay in sync, and a regression test asserts the default `parking-v0` horizon is ~100 policy steps (±1 step, from floating-point accumulation of `1 / policy_frequency` in the shared time counter — a pre-existing quirk left untouched here).

⚠️ **Environment behaviour change (flagged per CONTRIBUTING.md):** the default `parking-v0` episode horizon shrinks from 500 to ~100 policy steps for anyone relying on the default config. This restores the horizon that the published hyperparameter recipes and previous env semantics assumed, but maintainers may want to consider whether a version bump is warranted.

No new dependencies.

Fixes #674

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — only in the sense that default `parking-v0` episodes shorten from 500 to ~100 steps; users who tuned against the unintended 500-step horizon would be affected. Flagged per the CONTRIBUTING.md clause on environment behaviour changes.
- [x] This change requires a documentation update — done in this PR (`docs/environments/parking.md`).

### Screenshots

N/A — config default change, no rendering or visual behaviour affected.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (161 passed, 2 skipped; total coverage 86.30% ≥ 85%)
- [ ] If my code may add latency, I've tested locally and provided details in description above — N/A, no runtime cost added (config default + test only)
