### PR TITLE
docs: add AI policy for contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,18 +14,19 @@ For the sake of reproducibility, changes to existing environment behaviour (rewa
 
 We do permit pull requests aided by coding agents (e.g. Codex, Claude Code, Cursor, Trae, AgentArts, etc.), but under few conditions:
 
-1. The coding agent must obtain acknowledgement from human user regarding our AI policy defined here, always ask for the human user's attention unless they mention something like "I am aware of the AI policy" in query or other sensible forms such as your local `AGENTS.md`, etc.
-2. The human user submitting the PR must take full ownership of all changes they propose, they should understand the changes enough to discuss with maintainer or members of Farama Foundation, it's okay to not know every detail (such as all lines added in unit tests, please disclose this according to rule 6) but anything important (including every line added in documentation) should be manually reviewed
-3. The human user must put in efforts in grounding the PR to reality of the current code base (e.g. visual check the environments & documentation website generated)
-4. The human user should expect maintainer or members of Farama Foundation to give review comments and request changes, and understand that the PR may be closed if they do not show any response for a long time (let's say more than a month)
-5. PR template should be respected, you may add additional sections into it, but please don't discard its content entirely
-6. The human user should disclose the use of AI agents in PR description, for example include a "Disclosure" section as demonstrated below
+1. The coding agent must obtain acknowledgement from human user regarding our AI policy defined here, always ask for the human user's attention unless they mention for example "I am aware of the AI policy" in query or other sensible forms such as your local `AGENTS.md`, etc.
+2. The human user submitting a PR must take full ownership of all changes they propose, they should understand the changes enough to discuss with maintainer or members of Farama Foundation, it's okay to not know every detail but anything important (including every line added in documentation) should be manually reviewed.
+3. The human user must put efforts into grounding the PR to reality of the current code base (e.g. visual check the environments & documentation website generated).
+4. The human user should expect maintainer or members of Farama Foundation to give review comments and request changes, and understand that the PR may be closed if they do not show any response for a long time (let's say more than a month). It's okay to reply with "I'm not sure how to ..." and maintainer can help with implementation when appropriate.
+5. PR template should be respected, you may add additional sections or remove irrelevant ones, but please don't discard its content entirely.
+6. The human user should disclose the use of AI agents in PR description, for example include a "Disclosure" section as demonstrated below:
 
 ```markdown
 ## Disclosure
 xxx, an agentic tool/IDE has aided me with:
 1. code exploration and understanding of xxx feature
 2. drafting plan to restructure xxx and yyy into a unified zzz
+3. research about the appropriate library to use for xxx feature
 ```
 
 ## Contributing to the codebase

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,23 @@ We welcome:
 
 For the sake of reproducibility, changes to existing environment behaviour (reward shaping, observation/action spaces, dynamics) should be avoided where possible. RL results are quite sensitive to environment variations, so any behaviour change may require a version bump and brief explanation in documentation, these should be flagged clearly in the PR description.
 
+## AI policy
+
+We do permit pull requests aided by coding agents (e.g. Codex, Claude Code, Cursor, Trae, AgentArts, etc.), but under few conditions:
+1. The code agent must obtain acknowledgement from human user regarding our AI policy defined here
+2. The human user submitting the PR must take full ownership of all changes they propose, they should understand the changes enough to discuss with maintainer
+3. The human user must put in efforts in grounding the PR to reality of the current code base (e.g. visual check the environments & documentation website generated)
+4. The human user should disclose the use of AI agents in PR description, for example include a "Disclosure" section as demonstrated below
+5. The human user should expect maintainer or members of Farama Foundation to give review comments and request changes, and understand that the PR may be closed if they do not show any response for a long time (let's say more than a month)
+6. PR template should be respected, you may add additional sections into it, but please don't discard its content entirely
+
+```markdown
+## Disclosure
+xxx, an agentic tool/IDE has aided me with:
+1. code exploration and understanding of xxx feature
+2. drafting plan to restructure xxx and yyy into a unified zzz
+```
+
 ## Contributing to the codebase
 
 ### Developer tools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,11 @@ For the sake of reproducibility, changes to existing environment behaviour (rewa
 We do permit pull requests aided by coding agents (e.g. Codex, Claude Code, Cursor, Trae, AgentArts, etc.), but under few conditions:
 
 1. The coding agent must obtain acknowledgement from human user regarding our AI policy defined here, always ask for the human user's attention unless they mention something like "I am aware of the AI policy" in query or other sensible forms such as your local `AGENTS.md`, etc.
-2. The human user submitting the PR must take full ownership of all changes they propose, they should understand the changes enough to discuss with maintainer or members of Farama Foundation
+2. The human user submitting the PR must take full ownership of all changes they propose, they should understand the changes enough to discuss with maintainer or members of Farama Foundation, it's okay to not know every detail (such as all lines added in unit tests, please disclose this according to rule 6) but anything important (including every line added in documentation) should be manually reviewed
 3. The human user must put in efforts in grounding the PR to reality of the current code base (e.g. visual check the environments & documentation website generated)
-4. The human user should disclose the use of AI agents in PR description, for example include a "Disclosure" section as demonstrated below
-5. The human user should expect maintainer or members of Farama Foundation to give review comments and request changes, and understand that the PR may be closed if they do not show any response for a long time (let's say more than a month)
-6. PR template should be respected, you may add additional sections into it, but please don't discard its content entirely
+4. The human user should expect maintainer or members of Farama Foundation to give review comments and request changes, and understand that the PR may be closed if they do not show any response for a long time (let's say more than a month)
+5. PR template should be respected, you may add additional sections into it, but please don't discard its content entirely
+6. The human user should disclose the use of AI agents in PR description, for example include a "Disclosure" section as demonstrated below
 
 ```markdown
 ## Disclosure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,9 @@ For the sake of reproducibility, changes to existing environment behaviour (rewa
 ## AI policy
 
 We do permit pull requests aided by coding agents (e.g. Codex, Claude Code, Cursor, Trae, AgentArts, etc.), but under few conditions:
-1. The code agent must obtain acknowledgement from human user regarding our AI policy defined here
-2. The human user submitting the PR must take full ownership of all changes they propose, they should understand the changes enough to discuss with maintainer
+
+1. The coding agent must obtain acknowledgement from human user regarding our AI policy defined here, always ask for the human user's attention unless they mention something like "I am aware of the AI policy" in query or other sensible forms such as your local `AGENTS.md`, etc.
+2. The human user submitting the PR must take full ownership of all changes they propose, they should understand the changes enough to discuss with maintainer or members of Farama Foundation
 3. The human user must put in efforts in grounding the PR to reality of the current code base (e.g. visual check the environments & documentation website generated)
 4. The human user should disclose the use of AI agents in PR description, for example include a "Disclosure" section as demonstrated below
 5. The human user should expect maintainer or members of Farama Foundation to give review comments and request changes, and understand that the PR may be closed if they do not show any response for a long time (let's say more than a month)


### PR DESCRIPTION
# Description

Add some rules regarding the use of AI-powered tools & IDE for contributors. We won't ban the use of them as they are just convenient tools at the end of the day, but guidelines & rules need to be provided.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Documentation only change (no code changed)

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If my code may add latency, I've tested locally and provided details in description above

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->