### PR TITLE
fix(envs): add nested config validation in default_config override

### DIFF
--- a/highway_env/envs/common/abstract.py
+++ b/highway_env/envs/common/abstract.py
@@ -33,7 +33,7 @@ class ConnectedLaneNeighboursMixin:
     @classmethod
     def default_config(cls) -> dict:
         config = super().default_config()
-        config.update({"neighbour_vehicles_connected_lanes": True})
+        utils.update_config(config, {"neighbour_vehicles_connected_lanes": True})
         return config
 
 

--- a/highway_env/envs/exit_env.py
+++ b/highway_env/envs/exit_env.py
@@ -18,7 +18,8 @@ class ExitEnv(HighwayEnv):
     @classmethod
     def default_config(cls) -> dict:
         config = super().default_config()
-        config.update(
+        utils.update_config(
+            config,
             {
                 "observation": {
                     "type": "ExitObservation",
@@ -39,7 +40,7 @@ class ExitEnv(HighwayEnv):
                 "duration": 18,  # [s],
                 "simulation_frequency": 5,
                 "scaling": 5,
-            }
+            },
         )
         return config
 

--- a/highway_env/envs/highway_env.py
+++ b/highway_env/envs/highway_env.py
@@ -25,7 +25,8 @@ class HighwayEnv(AbstractEnv):
     @classmethod
     def default_config(cls) -> dict:
         config = super().default_config()
-        config.update(
+        utils.update_config(
+            config,
             {
                 "observation": {"type": "Kinematics"},
                 "action": {
@@ -47,7 +48,7 @@ class HighwayEnv(AbstractEnv):
                 "reward_speed_range": [20, 30],
                 "normalize_reward": True,
                 "offroad_terminal": False,
-            }
+            },
         )
         return config
 
@@ -161,14 +162,15 @@ class HighwayEnvFast(HighwayEnv):
     @classmethod
     def default_config(cls) -> dict:
         cfg = super().default_config()
-        cfg.update(
+        utils.update_config(
+            cfg,
             {
                 "simulation_frequency": 5,
                 "lanes_count": 3,
                 "vehicles_count": 20,
                 "duration": 30,  # [s]
                 "ego_spacing": 1.5,
-            }
+            },
         )
         return cfg
 

--- a/highway_env/envs/intersection_env.py
+++ b/highway_env/envs/intersection_env.py
@@ -17,7 +17,8 @@ class IntersectionEnv(AbstractEnv):
     @classmethod
     def default_config(cls) -> dict:
         config = super().default_config()
-        config.update(
+        utils.update_config(
+            config,
             {
                 "observation": {
                     "type": "Kinematics",
@@ -54,7 +55,7 @@ class IntersectionEnv(AbstractEnv):
                 "reward_speed_range": [7.0, 9.0],
                 "normalize_reward": False,
                 "offroad_terminal": False,
-            }
+            },
         )
         return config
 
@@ -376,7 +377,8 @@ class MultiAgentIntersectionEnv(IntersectionEnv):
     @classmethod
     def default_config(cls) -> dict:
         config = super().default_config()
-        config.update(
+        utils.update_config(
+            config,
             {
                 "action": {
                     "type": "MultiAgentAction",
@@ -391,7 +393,7 @@ class MultiAgentIntersectionEnv(IntersectionEnv):
                     "observation_config": {"type": "Kinematics"},
                 },
                 "controlled_vehicles": 2,
-            }
+            },
         )
         return config
 
@@ -410,7 +412,8 @@ class ContinuousIntersectionEnv(IntersectionEnv):
     @classmethod
     def default_config(cls) -> dict:
         config = super().default_config()
-        config.update(
+        utils.update_config(
+            config,
             {
                 "observation": {
                     "type": "Kinematics",
@@ -433,6 +436,6 @@ class ContinuousIntersectionEnv(IntersectionEnv):
                     "lateral": True,
                     "dynamical": True,
                 },
-            }
+            },
         )
         return config

--- a/highway_env/envs/intersection_env.py
+++ b/highway_env/envs/intersection_env.py
@@ -382,15 +382,53 @@ class MultiAgentIntersectionEnv(IntersectionEnv):
             {
                 "action": {
                     "type": "MultiAgentAction",
+                    # Parent DiscreteMetaAction keys (unused by MultiAgentAction; check-only).
+                    "longitudinal": True,
+                    "lateral": False,
+                    "target_speeds": [0, 4.5, 9],
                     "action_config": {
                         "type": "DiscreteMetaAction",
                         "lateral": False,
                         "longitudinal": True,
+                        "target_speeds": [0, 4.5, 9],
                     },
                 },
                 "observation": {
                     "type": "MultiAgentObservation",
-                    "observation_config": {"type": "Kinematics"},
+                    # Parent Kinematics keys (unused by MultiAgentObservation; check-only).
+                    "vehicles_count": 15,
+                    "features": ["presence", "x", "y", "vx", "vy", "cos_h", "sin_h"],
+                    "features_range": {
+                        "x": [-100, 100],
+                        "y": [-100, 100],
+                        "vx": [-20, 20],
+                        "vy": [-20, 20],
+                    },
+                    "absolute": True,
+                    "flatten": False,
+                    "observe_intentions": False,
+                    "observation_config": {
+                        "type": "Kinematics",
+                        "vehicles_count": 15,
+                        "features": [
+                            "presence",
+                            "x",
+                            "y",
+                            "vx",
+                            "vy",
+                            "cos_h",
+                            "sin_h",
+                        ],
+                        "features_range": {
+                            "x": [-100, 100],
+                            "y": [-100, 100],
+                            "vx": [-20, 20],
+                            "vy": [-20, 20],
+                        },
+                        "absolute": True,
+                        "flatten": False,
+                        "observe_intentions": False,
+                    },
                 },
                 "controlled_vehicles": 2,
             },
@@ -428,6 +466,15 @@ class ContinuousIntersectionEnv(IntersectionEnv):
                         "lat_off",
                         "ang_off",
                     ],
+                    "features_range": {
+                        "x": [-100, 100],
+                        "y": [-100, 100],
+                        "vx": [-20, 20],
+                        "vy": [-20, 20],
+                    },
+                    "absolute": True,
+                    "flatten": False,
+                    "observe_intentions": False,
                 },
                 "action": {
                     "type": "ContinuousAction",
@@ -435,6 +482,8 @@ class ContinuousIntersectionEnv(IntersectionEnv):
                     "longitudinal": True,
                     "lateral": True,
                     "dynamical": True,
+                    # Parent DiscreteMetaAction key (unused by ContinuousAction; check-only).
+                    "target_speeds": [0, 4.5, 9],
                 },
             },
         )

--- a/highway_env/envs/intersection_env.py
+++ b/highway_env/envs/intersection_env.py
@@ -382,9 +382,6 @@ class MultiAgentIntersectionEnv(IntersectionEnv):
             {
                 "action": {
                     "type": "MultiAgentAction",
-                    "longitudinal": True,
-                    "lateral": False,
-                    "target_speeds": [0, 4.5, 9],
                     "action_config": {
                         "type": "DiscreteMetaAction",
                         "lateral": False,
@@ -394,17 +391,6 @@ class MultiAgentIntersectionEnv(IntersectionEnv):
                 },
                 "observation": {
                     "type": "MultiAgentObservation",
-                    "vehicles_count": 15,
-                    "features": ["presence", "x", "y", "vx", "vy", "cos_h", "sin_h"],
-                    "features_range": {
-                        "x": [-100, 100],
-                        "y": [-100, 100],
-                        "vx": [-20, 20],
-                        "vy": [-20, 20],
-                    },
-                    "absolute": True,
-                    "flatten": False,
-                    "observe_intentions": False,
                     "observation_config": {
                         "type": "Kinematics",
                         "vehicles_count": 15,

--- a/highway_env/envs/intersection_env.py
+++ b/highway_env/envs/intersection_env.py
@@ -382,7 +382,6 @@ class MultiAgentIntersectionEnv(IntersectionEnv):
             {
                 "action": {
                     "type": "MultiAgentAction",
-                    # Parent DiscreteMetaAction keys (unused by MultiAgentAction; check-only).
                     "longitudinal": True,
                     "lateral": False,
                     "target_speeds": [0, 4.5, 9],
@@ -395,7 +394,6 @@ class MultiAgentIntersectionEnv(IntersectionEnv):
                 },
                 "observation": {
                     "type": "MultiAgentObservation",
-                    # Parent Kinematics keys (unused by MultiAgentObservation; check-only).
                     "vehicles_count": 15,
                     "features": ["presence", "x", "y", "vx", "vy", "cos_h", "sin_h"],
                     "features_range": {
@@ -482,7 +480,6 @@ class ContinuousIntersectionEnv(IntersectionEnv):
                     "longitudinal": True,
                     "lateral": True,
                     "dynamical": True,
-                    # Parent DiscreteMetaAction key (unused by ContinuousAction; check-only).
                     "target_speeds": [0, 4.5, 9],
                 },
             },

--- a/highway_env/envs/lane_keeping_env.py
+++ b/highway_env/envs/lane_keeping_env.py
@@ -4,6 +4,7 @@ import copy
 
 import numpy as np
 
+from highway_env import utils
 from highway_env.envs.common.abstract import AbstractEnv
 from highway_env.road.lane import LineType, SineLane, StraightLane
 from highway_env.road.road import Road, RoadNetwork
@@ -24,7 +25,8 @@ class LaneKeepingEnv(AbstractEnv):
     @classmethod
     def default_config(cls) -> dict:
         config = super().default_config()
-        config.update(
+        utils.update_config(
+            config,
             {
                 "observation": {
                     "type": "AttributesObservation",
@@ -45,7 +47,7 @@ class LaneKeepingEnv(AbstractEnv):
                 "screen_height": 250,
                 "scaling": 7,
                 "centering_position": [0.4, 0.5],
-            }
+            },
         )
         return config
 

--- a/highway_env/envs/merge_env.py
+++ b/highway_env/envs/merge_env.py
@@ -24,7 +24,8 @@ class MergeEnv(AbstractEnv):
     @classmethod
     def default_config(cls) -> dict:
         cfg = super().default_config()
-        cfg.update(
+        utils.update_config(
+            cfg,
             {
                 "collision_reward": -1,
                 "right_lane_reward": 0.1,
@@ -32,7 +33,7 @@ class MergeEnv(AbstractEnv):
                 "reward_speed_range": [20, 30],
                 "merging_speed_reward": -0.5,
                 "lane_change_reward": -0.05,
-            }
+            },
         )
         return cfg
 
@@ -216,7 +217,8 @@ class MergeGenericEnv(MergeEnv):
     @classmethod
     def default_config(cls) -> dict:
         cfg = super().default_config()
-        cfg.update(
+        utils.update_config(
+            cfg,
             {
                 "lanes_count": 2,
                 "vehicles_count": 3,
@@ -229,7 +231,7 @@ class MergeGenericEnv(MergeEnv):
                 "parallel_merge_length": 80,
                 # Section after the merge segment (must be >= 90)
                 "after_merge_length": 150,
-            }
+            },
         )
         return cfg
 

--- a/highway_env/envs/parking_env.py
+++ b/highway_env/envs/parking_env.py
@@ -6,6 +6,7 @@ from itertools import repeat
 import numpy as np
 from gymnasium import Env
 
+from highway_env import utils
 from highway_env.envs.common.abstract import AbstractEnv
 from highway_env.envs.common.observation import (
     MultiAgentObservation,
@@ -86,7 +87,8 @@ class ParkingEnv(AbstractEnv, GoalEnv):
     @classmethod
     def default_config(cls) -> dict:
         config = super().default_config()
-        config.update(
+        utils.update_config(
+            config,
             {
                 "observation": {
                     "type": "KinematicsGoal",
@@ -109,7 +111,7 @@ class ParkingEnv(AbstractEnv, GoalEnv):
                 "controlled_vehicles": 1,
                 "vehicles_count": 0,
                 "add_walls": True,
-            }
+            },
         )
         return config
 

--- a/highway_env/envs/racetrack_env.py
+++ b/highway_env/envs/racetrack_env.py
@@ -28,7 +28,8 @@ class RacetrackEnv(AbstractEnv):
     @classmethod
     def default_config(cls) -> dict:
         config = super().default_config()
-        config.update(
+        utils.update_config(
+            config,
             {
                 "observation": {
                     "type": "OccupancyGrid",
@@ -58,7 +59,7 @@ class RacetrackEnv(AbstractEnv):
                 "centering_position": [0.5, 0.5],
                 "speed_limit": 10.0,
                 "terminate_off_road": True,
-            }
+            },
         )
         return config
 
@@ -893,7 +894,8 @@ class RacetrackEnvOval(RacetrackEnv):
     @classmethod
     def default_config(cls) -> dict:
         config = super().default_config()
-        config.update(
+        utils.update_config(
+            config,
             {
                 "observation": {
                     "type": "OccupancyGrid",
@@ -927,7 +929,7 @@ class RacetrackEnvOval(RacetrackEnv):
                 "no_lanes": 3,  # 0: random number from [2,7]
                 "block_lane": False,  # block middle lane
                 "force_decision": False,  # block 1st and 3rd lane
-            }
+            },
         )
         return config
 

--- a/highway_env/envs/roundabout_env.py
+++ b/highway_env/envs/roundabout_env.py
@@ -13,7 +13,8 @@ class RoundaboutEnv(AbstractEnv):
     @classmethod
     def default_config(cls) -> dict:
         config = super().default_config()
-        config.update(
+        utils.update_config(
+            config,
             {
                 "observation": {
                     "type": "Kinematics",
@@ -36,7 +37,7 @@ class RoundaboutEnv(AbstractEnv):
                 "centering_position": [0.5, 0.6],
                 "duration": 11,
                 "normalize_reward": True,
-            }
+            },
         )
         return config
 
@@ -406,13 +407,14 @@ class RoundaboutGenericEnv(RoundaboutEnv):
     @classmethod
     def default_config(cls) -> dict:
         config = super().default_config()
-        config.update(
+        utils.update_config(
+            config,
             {
                 "roundabout_radius": 20,
                 "roundabout_lanes": 2,
                 "vehicles_count": 5,
                 "duration": 17,
-            }
+            },
         )
         return config
 

--- a/highway_env/envs/two_way_env.py
+++ b/highway_env/envs/two_way_env.py
@@ -21,7 +21,8 @@ class TwoWayEnv(AbstractEnv):
     @classmethod
     def default_config(cls) -> dict:
         config = super().default_config()
-        config.update(
+        utils.update_config(
+            config,
             {
                 "observation": {"type": "TimeToCollision", "horizon": 5},
                 "action": {
@@ -31,7 +32,7 @@ class TwoWayEnv(AbstractEnv):
                 "left_lane_constraint": 1,
                 "left_lane_reward": 0.2,
                 "high_speed_reward": 0.8,
-            }
+            },
         )
         return config
 

--- a/highway_env/envs/u_turn_env.py
+++ b/highway_env/envs/u_turn_env.py
@@ -18,7 +18,8 @@ class UTurnEnv(AbstractEnv):
     @classmethod
     def default_config(cls) -> dict:
         config = super().default_config()
-        config.update(
+        utils.update_config(
+            config,
             {
                 "observation": {"type": "TimeToCollision", "horizon": 16},
                 "action": {"type": "DiscreteMetaAction", "target_speeds": [8, 16, 24]},
@@ -31,7 +32,7 @@ class UTurnEnv(AbstractEnv):
                 "reward_speed_range": [8, 24],
                 "normalize_reward": True,
                 "offroad_terminal": False,
-            }
+            },
         )
         return config
 

--- a/highway_env/utils.py
+++ b/highway_env/utils.py
@@ -441,8 +441,8 @@ def update_config_check(config: dict[str, Any], delta: Mapping[str, Any]) -> Non
     """
     Check that nested mapping values in ``delta`` redefine all keys from ``config``.
 
-    :param config: Existing configuration mapping
-    :param delta: Configuration update mapping
+    :param config: Configuration dict to update
+    :param delta: Values to apply on top of ``config``
     """
     for key, val in config.items():
         if key not in delta or not isinstance(val, Mapping):

--- a/highway_env/utils.py
+++ b/highway_env/utils.py
@@ -439,7 +439,7 @@ def track_config_path(key: str):
 
 def update_config_check(config: dict[str, Any], delta: Mapping[str, Any]) -> None:
     """
-    Assert that nested mapping values in ``delta`` redefine all keys from ``config``.
+    Check that nested mapping values in ``delta`` redefine all keys from ``config``.
 
     :param config: Existing configuration mapping
     :param delta: Configuration update mapping
@@ -453,6 +453,14 @@ def update_config_check(config: dict[str, Any], delta: Mapping[str, Any]) -> Non
             assert isinstance(
                 new_val, Mapping
             ), f"{path} must be a mapping, got {type(new_val).__name__}"
+
+            # Handle multi-agent environments where keys are not defined in outer dict
+            if key in ("action", "observation"):
+                new_val = dict(new_val)
+                nested = new_val.get(key + "_config")
+                if isinstance(nested, Mapping):
+                    new_val.update(nested)
+
             missing_keys = val.keys() - new_val.keys()
             assert not missing_keys, f"{path} invalid: {missing_keys=}"
             update_config_check(val, new_val)

--- a/highway_env/utils.py
+++ b/highway_env/utils.py
@@ -456,10 +456,9 @@ def update_config_check(config: dict[str, Any], delta: Mapping[str, Any]) -> Non
 
             # Handle multi-agent environments where keys are not defined in outer dict
             if key in ("action", "observation"):
-                new_val = dict(new_val)
                 nested = new_val.get(key + "_config")
                 if isinstance(nested, Mapping):
-                    new_val.update(nested)
+                    new_val = new_val | nested
 
             missing_keys = val.keys() - new_val.keys()
             assert not missing_keys, f"{path} invalid: {missing_keys=}"

--- a/highway_env/utils.py
+++ b/highway_env/utils.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import copy
 import importlib
 import itertools
-from typing import Callable, List, Sequence, Tuple, Union
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Callable, List, Mapping, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -420,3 +422,50 @@ def solve_trinom(a, b, c):
         return (-b - np.sqrt(delta)) / (2 * a), (-b + np.sqrt(delta)) / (2 * a)
     else:
         return None, None
+
+
+_config_path: ContextVar[str] = ContextVar("_config_path", default="config")
+
+
+@contextmanager
+def track_config_path(key: str):
+    """A context manager to trace config path for meaningful error message."""
+    token = _config_path.set(f"{_config_path.get()}.{key}")
+    try:
+        yield
+    finally:
+        _config_path.reset(token)
+
+
+def update_config_check(config: dict[str, Any], delta: Mapping[str, Any]) -> None:
+    """
+    Assert that nested mapping values in ``delta`` redefine all keys from ``config``.
+
+    :param config: Existing configuration mapping
+    :param delta: Configuration update mapping
+    """
+    for key, val in config.items():
+        if key not in delta or not isinstance(val, Mapping):
+            continue
+        with track_config_path(key):
+            path = _config_path.get()
+            new_val = delta[key]
+            assert isinstance(
+                new_val, Mapping
+            ), f"{path} must be a mapping, got {type(new_val).__name__}"
+            missing_keys = val.keys() - new_val.keys()
+            assert not missing_keys, f"{path} invalid: {missing_keys=}"
+            update_config_check(val, new_val)
+
+
+def update_config(config: dict[str, Any], delta: Mapping[str, Any]) -> dict[str, Any]:
+    """
+    Update ``config`` in place with ``delta`` after validating nested mappings.
+
+    :param config: Configuration dict to update
+    :param delta: Values to apply on top of ``config``
+    :return: The updated ``config`` dict
+    """
+    update_config_check(config, delta)
+    config.update(delta)
+    return config

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -211,3 +211,80 @@ def test_update_config_propagates_check_error():
     config = {"observation": {"type": "Kinematics", "absolute": True}}
     with pytest.raises(AssertionError, match=r"^config\.observation invalid:"):
         update_config(config, {"observation": {"type": "Kinematics"}})
+
+
+def test_update_config_check_multiagent_nested_configs():
+    config = {
+        "action": {
+            "type": "DiscreteMetaAction",
+            "longitudinal": True,
+            "lateral": False,
+            "target_speeds": [0, 4.5, 9],
+        },
+        "observation": {
+            "type": "Kinematics",
+            "vehicles_count": 15,
+            "features": ["presence", "x", "y", "vx", "vy", "cos_h", "sin_h"],
+            "features_range": {
+                "x": [-100, 100],
+                "y": [-100, 100],
+                "vx": [-20, 20],
+                "vy": [-20, 20],
+            },
+            "absolute": True,
+            "flatten": False,
+            "observe_intentions": False,
+        },
+    }
+    delta = {
+        "action": {
+            "type": "MultiAgentAction",
+            "action_config": {
+                "type": "DiscreteMetaAction",
+                "longitudinal": True,
+                "lateral": False,
+                "target_speeds": [0, 4.5, 9],
+            },
+        },
+        "observation": {
+            "type": "MultiAgentObservation",
+            "observation_config": {
+                "type": "Kinematics",
+                "vehicles_count": 15,
+                "features": ["presence", "x", "y", "vx", "vy", "cos_h", "sin_h"],
+                "features_range": {
+                    "x": [-100, 100],
+                    "y": [-100, 100],
+                    "vx": [-20, 20],
+                    "vy": [-20, 20],
+                },
+                "absolute": True,
+                "flatten": False,
+                "observe_intentions": False,
+            },
+        },
+    }
+    update_config_check(config, delta)
+
+
+def test_update_config_check_multiagent_nested_features_range_message():
+    config = {
+        "observation": {
+            "type": "Kinematics",
+            "features_range": {"x": [-100, 100], "y": [-100, 100]},
+        }
+    }
+    delta = {
+        "observation": {
+            "type": "MultiAgentObservation",
+            "observation_config": {
+                "type": "Kinematics",
+                "features_range": {"x": [-50, 50]},
+            },
+        }
+    }
+    with pytest.raises(
+        AssertionError,
+        match=r"^config\.observation\.features_range invalid: missing_keys=\{'y'\}$",
+    ):
+        update_config_check(config, delta)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,8 @@ from highway_env.utils import (
     near_split,
     rotated_rectangles_intersect,
     solve_trinom,
+    update_config,
+    update_config_check,
 )
 
 
@@ -126,3 +128,86 @@ def test_distance_to_rect_no_intersection():
 def test_solve_trinom():
     assert solve_trinom(1.0, -3.0, 2.0) == pytest.approx((1.0, 2.0))
     assert solve_trinom(1.0, 0.0, 1.0) == (None, None)
+
+
+def test_update_config_allows_complete_nested_override():
+    config = {
+        "observation": {
+            "type": "Kinematics",
+            "vehicles_count": 15,
+            "absolute": True,
+        },
+        "duration": 13,
+    }
+    delta = {
+        "observation": {
+            "type": "Kinematics",
+            "vehicles_count": 5,
+            "absolute": False,
+        },
+        "lanes_count": 4,
+    }
+    result = update_config(config, delta)
+    assert result is config
+    assert config["observation"]["vehicles_count"] == 5
+    assert config["lanes_count"] == 4
+
+
+def test_update_config_check_missing_keys_message():
+    config = {
+        "observation": {
+            "type": "Kinematics",
+            "absolute": True,
+            "flatten": False,
+            "observe_intentions": False,
+            "features_range": {"x": [-100, 100], "y": [-100, 100]},
+        }
+    }
+    delta = {
+        "observation": {
+            "type": "Kinematics",
+            "absolute": True,
+        }
+    }
+    with pytest.raises(AssertionError, match=r"^config\.observation invalid:") as exc:
+        update_config_check(config, delta)
+    message = str(exc.value)
+    assert "missing_keys=" in message
+    assert "flatten" in message
+    assert "observe_intentions" in message
+    assert "features_range" in message
+
+
+def test_update_config_check_nested_path_message():
+    config = {
+        "observation": {
+            "type": "Kinematics",
+            "features_range": {"x": [-100, 100], "y": [-100, 100]},
+        }
+    }
+    delta = {
+        "observation": {
+            "type": "Kinematics",
+            "features_range": {"x": [-50, 50]},
+        }
+    }
+    with pytest.raises(
+        AssertionError,
+        match=r"^config\.observation\.features_range invalid: missing_keys=\{'y'\}$",
+    ):
+        update_config_check(config, delta)
+
+
+def test_update_config_check_non_mapping_message():
+    config = {"action": {"type": "DiscreteMetaAction", "lateral": False}}
+    with pytest.raises(
+        AssertionError,
+        match=r"^config\.action must be a mapping, got str$",
+    ):
+        update_config_check(config, {"action": "bad"})
+
+
+def test_update_config_propagates_check_error():
+    config = {"observation": {"type": "Kinematics", "absolute": True}}
+    with pytest.raises(AssertionError, match=r"^config\.observation invalid:"):
+        update_config(config, {"observation": {"type": "Kinematics"}})


### PR DESCRIPTION
# Description

Nested config keys can be silently discarded if we just use `dict.update(...)`, as reported in #723.

Fixes #723 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New environment or environment variant
- [ ] Performance improvement (non-breaking change that improves speed, memory, or resource usage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Compatibility fix or other chore tasks
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If my code may add latency, I've tested locally and provided details in description above

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
