### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build-wheels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/HighwayEnv/security/code-scanning/2](https://github.com/Farama-Foundation/HighwayEnv/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults, and keep job-specific elevation only where needed.

Best single fix here:
- In `.github/workflows/publish.yml`, insert at top-level (after `on:` block, before `jobs:`):
  - `permissions:`
  - `contents: read`
- Keep the existing `publish` job `permissions: id-token: write` unchanged; it remains necessary for PyPI trusted publishing via OIDC.
  
This preserves existing functionality while explicitly limiting default token scope for `build-wheels` (and any future jobs without their own override).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
