### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ on:
       - 'highway_env/**'
       - 'tests/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/HighwayEnv/security/code-scanning/1](https://github.com/Farama-Foundation/HighwayEnv/security/code-scanning/1)

Add an explicit `permissions` block so the workflow does not inherit potentially broad defaults.  
Best fix here: define permissions at the workflow root (applies to all jobs unless overridden), with the minimum needed for this pipeline:

- `contents: read` (required for checkout and repository read access)

Edit `.github/workflows/build.yml` near the top-level keys, inserting `permissions:` between `on:` and `jobs:` (or directly under `name:` / `on:` at root level). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
